### PR TITLE
Feature/create network module

### DIFF
--- a/Projects/Core/Networker/Sources/Implement/Networker.swift
+++ b/Projects/Core/Networker/Sources/Implement/Networker.swift
@@ -1,0 +1,122 @@
+//
+//  Networker.swift
+//  Networker
+//
+//  Created by 조용인 on 3/14/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import Utility
+
+public struct Networker: NetworkProtocol, Sendable {
+  
+  private let session: URLSession
+  
+  public init(
+    session: URLSession = .shared
+  ) {
+    self.session = session
+  }
+  
+  public func execute<E: APIRequestable>(
+    with endpoint: E,
+    timeout: TimeInterval = 30.0
+  ) async throws -> E.Response where E.Response: Decodable & Sendable {
+    try await withThrowingTaskGroup(of: E.Response.self) { group in
+      group.addTask { // 실제 네트워크 통신 Task
+        let request = try endpoint.toURLRequest()
+        let (data, response) = try await self.session.data(for: request)
+        return try self.handleResponse(data: data, response: response, endpoint: endpoint)
+      }
+      
+      group.addTask { // 타임아웃 체크 전용 Task
+        try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+        throw NetworkError.timeout(timeout)
+      }
+      
+      do {
+        if let result = try await group.next() { // 먼저 완료되는 task 결과 처리 후, 나머지는 모두 취소시킴.
+          group.cancelAll()
+          return result
+        } else {
+          throw FoundationError.taskFailed
+        }
+      } catch {
+        group.cancelAll()
+        throw FoundationError.taskCancelled
+      }
+    }
+  }
+  
+  public func executeWithTask<E: APIRequestable>(
+    with endpoint: E,
+    timeout: TimeInterval = 30.0
+  ) -> Task<E.Response, Error> where E.Response: Decodable & Sendable {
+    return Task {
+      try Task.checkCancellation() // 시작 전 취소 확인
+      
+      return try await withThrowingTaskGroup(of: E.Response.self) { group in
+        
+        group.addTask { // 실제 네트워크 통신 Task
+          try Task.checkCancellation() // 요청 전 취소 확인
+          let request = try endpoint.toURLRequest()
+          try Task.checkCancellation() // 요청 직전 취소 확인
+          let (data, response) = try await self.session.data(for: request)
+          try Task.checkCancellation() // 응답 후 취소 확인
+          return try self.handleResponse(data: data, response: response, endpoint: endpoint)
+        }
+        
+        group.addTask { // 타임아웃 태스크
+          try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+          throw NetworkError.timeout(timeout)
+        }
+        
+        do {
+          if let result = try await group.next() { // 먼저 완료되는 task 결과 처리 후, 나머지는 모두 취소시킴
+            group.cancelAll()
+            return result
+          } else {
+            throw FoundationError.taskFailed
+          }
+        } catch {
+          group.cancelAll()
+          throw error
+        }
+      }
+    }
+  }
+}
+
+extension Networker {
+  fileprivate func handleResponse<R: Decodable & Sendable>(
+    data: Data,
+    response: URLResponse,
+    endpoint: any APIRequestable
+  ) throws -> R {
+    
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw  FoundationError.failedToCasting(from: URLResponse.self, to: HTTPURLResponse.self)
+    }
+    
+    guard (200..<300).contains(httpResponse.statusCode) else {
+      do {
+        let error = try JSONDecoder().decode(APIResponse<ErrorResponse>.self, from: data)
+        switch httpResponse.statusCode {
+        case 400...599: throw NetworkError.serverError(message: error.data.message, code: error.status)
+        default: throw NetworkError.invalidStatusCode(httpResponse.statusCode)
+        }
+      } catch {
+        throw NetworkError.invalidStatusCode(httpResponse.statusCode)
+      }
+    }
+    
+    do {
+      let decoder = JSONDecoder()
+      let response = try decoder.decode(R.self, from: data)
+      return response
+    } catch {
+      throw FoundationError.failedToDecode(error)
+    }
+  }
+}

--- a/Projects/Core/Networker/Sources/Interface/APIRequestable.swift
+++ b/Projects/Core/Networker/Sources/Interface/APIRequestable.swift
@@ -1,0 +1,65 @@
+//
+//  APIRequestable.swift
+//  Networker
+//
+//  Created by 조용인 on 3/14/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import Utility
+
+public typealias HTTPHeaders = [String: String]
+public typealias HTTPParameters = [String: Any]
+
+public enum HTTPRequestParameter {
+  case query(_ query: Encodable?)
+  case body(_ parameter: Encodable?)
+}
+
+public enum HTTPMethod: String {
+  case get = "GET"
+  case post = "POST"
+  case put = "PUT"
+  case delete = "DELETE"
+}
+
+public protocol APIRequestable {
+  associatedtype Response: Decodable
+  
+  var baseURL: URL? { get }
+  var method: HTTPMethod { get }
+  var headers: HTTPHeaders { get }
+  var path: String { get }
+  var parameters: HTTPRequestParameter? { get }
+  
+  func toURLRequest() throws -> URLRequest
+}
+
+public extension APIRequestable {
+  func toURLRequest() throws -> URLRequest {
+    let url = try configureURL()
+    var urlRequest = URLRequest(url: url)
+      .setMethod(self.method.rawValue)
+      .appendingHeaders(self.headers)
+    if let parameters = self.parameters {
+      switch parameters {
+      case let .body(body): urlRequest = try urlRequest.setBody(body)
+      case .query: break
+      }
+    }
+    return urlRequest
+  }
+  
+  fileprivate func configureURL() throws -> URL {
+    guard let baseURL = baseURL else { throw NSError(domain: "Encodable", code: 0, userInfo: nil) } // TODO: FoundationError로 변경
+    var url = baseURL.appendingPathComponent(path)
+    if let parameters = parameters {
+      switch parameters {
+      case let .query(queries): url = try url.appendingQueries(queries)
+      default: break
+      }
+    }
+    return url
+  }
+}

--- a/Projects/Core/Networker/Sources/Interface/APIRequestable.swift
+++ b/Projects/Core/Networker/Sources/Interface/APIRequestable.swift
@@ -52,7 +52,7 @@ public extension APIRequestable {
   }
   
   fileprivate func configureURL() throws -> URL {
-    guard let baseURL = baseURL else { throw NSError(domain: "Encodable", code: 0, userInfo: nil) } // TODO: FoundationError로 변경
+    guard let baseURL = baseURL else { throw FoundationError.thisValueIsNil(baseURL) }
     var url = baseURL.appendingPathComponent(path)
     if let parameters = parameters {
       switch parameters {

--- a/Projects/Core/Networker/Sources/Interface/APIRequestable.swift
+++ b/Projects/Core/Networker/Sources/Interface/APIRequestable.swift
@@ -25,7 +25,7 @@ public enum HTTPMethod: String {
 }
 
 public protocol APIRequestable {
-  associatedtype Response: Decodable
+  associatedtype Response: Decodable & Sendable
   
   var baseURL: URL? { get }
   var method: HTTPMethod { get }

--- a/Projects/Core/Networker/Sources/Interface/BaseResponse.swift
+++ b/Projects/Core/Networker/Sources/Interface/BaseResponse.swift
@@ -1,0 +1,16 @@
+//
+//  BaseResponse.swift
+//  Networker
+//
+//  Created by 조용인 on 3/14/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public struct APIResponse<R>: Decodable where R: Decodable {
+  let success: Bool?
+  let status: Int?
+  let timestamp: String?
+  let data: [R]
+}

--- a/Projects/Core/Networker/Sources/Interface/BaseResponse.swift
+++ b/Projects/Core/Networker/Sources/Interface/BaseResponse.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct APIResponse<R>: Decodable where R: Decodable {
+public struct APIResponse<R>: Decodable & Sendable where R: Decodable & Sendable {
   let success: Bool?
   let status: Int?
   let timestamp: String?

--- a/Projects/Core/Networker/Sources/Interface/BaseResponse.swift
+++ b/Projects/Core/Networker/Sources/Interface/BaseResponse.swift
@@ -9,10 +9,10 @@
 import Foundation
 
 public struct APIResponse<R>: Decodable & Sendable where R: Decodable & Sendable {
-  let success: Bool
-  let status: Int
-  let timestamp: String
-  let data: R?
+  public let success: Bool
+  public let status: Int
+  public let timestamp: String
+  public let data: R
   
-  var isSuccess: Bool { success && (200..<300).contains(status) && data != nil }
+  public var isSuccess: Bool { success && (200..<300).contains(status) }
 }

--- a/Projects/Core/Networker/Sources/Interface/BaseResponse.swift
+++ b/Projects/Core/Networker/Sources/Interface/BaseResponse.swift
@@ -12,5 +12,5 @@ public struct APIResponse<R>: Decodable & Sendable where R: Decodable & Sendable
   let success: Bool?
   let status: Int?
   let timestamp: String?
-  let data: [R]
+  let data: R?
 }

--- a/Projects/Core/Networker/Sources/Interface/BaseResponse.swift
+++ b/Projects/Core/Networker/Sources/Interface/BaseResponse.swift
@@ -9,8 +9,10 @@
 import Foundation
 
 public struct APIResponse<R>: Decodable & Sendable where R: Decodable & Sendable {
-  let success: Bool?
-  let status: Int?
-  let timestamp: String?
+  let success: Bool
+  let status: Int
+  let timestamp: String
   let data: R?
+  
+  var isSuccess: Bool { success && (200..<300).contains(status) && data != nil }
 }

--- a/Projects/Core/Networker/Sources/Interface/Endpoint.swift
+++ b/Projects/Core/Networker/Sources/Interface/Endpoint.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct EmptyResponse: Codable {}
 
-public struct Endpoint<R>: APIRequestable where R: Decodable {
+public struct Endpoint<R>: APIRequestable where R: Decodable & Sendable {
     public typealias Response = R
     
     public let headers: HTTPHeaders

--- a/Projects/Core/Networker/Sources/Interface/Endpoint.swift
+++ b/Projects/Core/Networker/Sources/Interface/Endpoint.swift
@@ -11,25 +11,25 @@ import Foundation
 struct EmptyResponse: Codable {}
 
 public struct Endpoint<R>: APIRequestable where R: Decodable & Sendable {
-    public typealias Response = R
-    
-    public let headers: HTTPHeaders
-    public let method: HTTPMethod
-    public let baseURL: URL?
-    public let path: String
-    public let parameters: HTTPRequestParameter?
-    
-    public init(
-        headers: HTTPHeaders = ["Content-Type": "application/json"],
-        method: HTTPMethod,
-        baseURL: String,
-        path: String,
-        parameters: HTTPRequestParameter? = nil
-    ) {
-        self.headers = headers
-        self.method = method
-        self.baseURL = URL(string:baseURL)
-        self.path = path
-        self.parameters = parameters
-    }
+  public typealias Response = R
+  
+  public let headers: HTTPHeaders
+  public let method: HTTPMethod
+  public let baseURL: URL?
+  public let path: String
+  public let parameters: HTTPRequestParameter?
+  
+  public init(
+    headers: HTTPHeaders = ["Content-Type": "application/json"],
+    method: HTTPMethod,
+    baseURL: String,
+    path: String,
+    parameters: HTTPRequestParameter? = nil
+  ) {
+    self.headers = headers
+    self.method = method
+    self.baseURL = URL(string:baseURL)
+    self.path = path
+    self.parameters = parameters
+  }
 }

--- a/Projects/Core/Networker/Sources/Interface/Endpoint.swift
+++ b/Projects/Core/Networker/Sources/Interface/Endpoint.swift
@@ -1,0 +1,35 @@
+//
+//  Endpoint.swift
+//  Networker
+//
+//  Created by 조용인 on 3/14/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+struct EmptyResponse: Codable {}
+
+public struct Endpoint<R>: APIRequestable where R: Decodable {
+    public typealias Response = R
+    
+    public let headers: HTTPHeaders
+    public let method: HTTPMethod
+    public let baseURL: URL?
+    public let path: String
+    public let parameters: HTTPRequestParameter?
+    
+    public init(
+        headers: HTTPHeaders = ["Content-Type": "application/json"],
+        method: HTTPMethod,
+        baseURL: String,
+        path: String,
+        parameters: HTTPRequestParameter? = nil
+    ) {
+        self.headers = headers
+        self.method = method
+        self.baseURL = URL(string:baseURL)
+        self.path = path
+        self.parameters = parameters
+    }
+}

--- a/Projects/Core/Networker/Sources/Interface/ErrorResponse.swift
+++ b/Projects/Core/Networker/Sources/Interface/ErrorResponse.swift
@@ -1,0 +1,14 @@
+//
+//  ErrorResponse.swift
+//  Networker
+//
+//  Created by 조용인 on 3/14/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public struct ErrorResponse: Decodable, Sendable {
+  public let errorClassName: String
+  public let message: String
+}

--- a/Projects/Core/Networker/Sources/Interface/NetworkError.swift
+++ b/Projects/Core/Networker/Sources/Interface/NetworkError.swift
@@ -1,0 +1,24 @@
+//
+//  NetworkError.swift
+//  Networker
+//
+//  Created by 조용인 on 3/14/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public enum NetworkError: Error, LocalizedError, Sendable {
+  
+  case invalidStatusCode(Int)
+  case timeout(TimeInterval)
+  case serverError(message: String, code: Int)
+  
+  public var errorDescription: String {
+    switch self {
+    case let .serverError(message, code): return "[에러코드: \(code)] - \(message)"
+    case let .invalidStatusCode(code): return "[잘못 된 StatusCode] - \(code)"
+    case let .timeout(time): return "[네트워크 요청 시간이 초과되었습니다.] - \(time)Seconds"
+    }
+  }
+}

--- a/Projects/Core/Networker/Sources/Interface/NetworkProtocol.swift
+++ b/Projects/Core/Networker/Sources/Interface/NetworkProtocol.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 public protocol NetworkProtocol {
-  func execute<E: APIRequestable>(with endpoint: E) async throws -> E.Response
+  func execute<E: APIRequestable>(with endpoint: E) async throws -> E.Response where E.Response: Decodable & Sendable
 }

--- a/Projects/Core/Networker/Sources/Interface/NetworkProtocol.swift
+++ b/Projects/Core/Networker/Sources/Interface/NetworkProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  NetworkProtocol.swift
+//  Networker
+//
+//  Created by 조용인 on 3/14/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public protocol NetworkProtocol {
+  func execute<E: APIRequestable>(with endpoint: E) async throws -> E.Response
+}

--- a/Projects/Core/Networker/Sources/Interface/NetworkProtocol.swift
+++ b/Projects/Core/Networker/Sources/Interface/NetworkProtocol.swift
@@ -9,5 +9,10 @@
 import Foundation
 
 public protocol NetworkProtocol {
+  /// 네트워크 통신을 위한 execute 메서드
   func execute<E: APIRequestable>(with endpoint: E) async throws -> E.Response where E.Response: Decodable & Sendable
+  /// Timeout을 설정하여 네트워크 통신을 위한 execute 메서드
+  func executeWithTimeout<E: APIRequestable>(with endpoint: E, timeout: TimeInterval) async throws -> E.Response where E.Response: Decodable & Sendable
+  /// Task의 checkCancellation를 통해, 네트워크 통신 도중의 cancel을 체크할 수 있음
+  func executeWithTask<E: APIRequestable>(with endpoint: E) -> Task<E.Response, Error> where E.Response: Decodable & Sendable
 }

--- a/Projects/Core/Networker/Sources/Interface/NetworkProtocol.swift
+++ b/Projects/Core/Networker/Sources/Interface/NetworkProtocol.swift
@@ -10,9 +10,7 @@ import Foundation
 
 public protocol NetworkProtocol {
   /// 네트워크 통신을 위한 execute 메서드
-  func execute<E: APIRequestable>(with endpoint: E) async throws -> E.Response where E.Response: Decodable & Sendable
-  /// Timeout을 설정하여 네트워크 통신을 위한 execute 메서드
-  func executeWithTimeout<E: APIRequestable>(with endpoint: E, timeout: TimeInterval) async throws -> E.Response where E.Response: Decodable & Sendable
+  func execute<E: APIRequestable>(with endpoint: E, timeout: TimeInterval) async throws -> E.Response where E.Response: Decodable & Sendable
   /// Task의 checkCancellation를 통해, 네트워크 통신 도중의 cancel을 체크할 수 있음
-  func executeWithTask<E: APIRequestable>(with endpoint: E) -> Task<E.Response, Error> where E.Response: Decodable & Sendable
+  func executeWithTask<E: APIRequestable>(with endpoint: E, timeout: TimeInterval) -> Task<E.Response, Error> where E.Response: Decodable & Sendable
 }

--- a/Projects/Core/Networker/Sources/source.swift
+++ b/Projects/Core/Networker/Sources/source.swift
@@ -1,1 +1,0 @@
-// add logic

--- a/Projects/Shared/Utility/Sources/Errors/FoundationError.swift
+++ b/Projects/Shared/Utility/Sources/Errors/FoundationError.swift
@@ -1,0 +1,36 @@
+//
+//  FoundationError.swift
+//  Utility
+//
+//  Created by 조용인 on 3/14/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public enum FoundationError: Error, LocalizedError, Sendable {
+  
+  case invalidBody
+  case failedToEncode(Error)
+  case failedToDecode(Error)
+  case failedToCreateURLComponents
+  case failedToCasting(from: Sendable, to: Sendable)
+  case thisValueIsNil(Sendable)
+  
+  case taskCancelled
+  case taskFailed
+  
+  public var errorDescription: String {
+    switch self {
+    case .invalidBody: return "[Body가 존재하지 않습니다.]"
+    case let .failedToEncode(error): return "[인코딩에 실패하였습니다.] - \(error.localizedDescription)"
+    case let .failedToDecode(error): return "[디코딩에 실패하였습니다.] - \(error.localizedDescription)"
+    case .failedToCreateURLComponents: return "[URLComponent 생성에 실패하였습니다.]"
+    case let .failedToCasting(from, to): return "[\(from)을(를) \(to)로 캐스팅 하는데 실패하였습니다.]"
+    case let .thisValueIsNil(type): return "[\(type)은(는) nil입니다.]"
+    
+    case .taskCancelled: return "[Task가 취소 되었습니다.]"
+    case .taskFailed: return "[Task가 실패 했습니다.]"
+    }
+  }
+}

--- a/Projects/Shared/Utility/Sources/Errors/NetworkError.swift
+++ b/Projects/Shared/Utility/Sources/Errors/NetworkError.swift
@@ -1,6 +1,6 @@
 //
 //  NetworkError.swift
-//  Networker
+//  Utility
 //
 //  Created by 조용인 on 3/14/25.
 //  Copyright © 2025 com.yongin.pida. All rights reserved.

--- a/Projects/Shared/Utility/Sources/Extensions/Encodable+.swift
+++ b/Projects/Shared/Utility/Sources/Extensions/Encodable+.swift
@@ -12,7 +12,7 @@ public extension Encodable {
   func toDictionary() throws -> [String: Any] {
     let data = try JSONEncoder().encode(self)
     let jsonData = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
-    guard let convertedDict = jsonData as? [String: Any] else { throw NSError(domain: "Encodable", code: 0, userInfo: nil) } // TODO: FoundationError로 변경
+    guard let convertedDict = jsonData as? [String: Any] else { throw FoundationError.failedToCasting(from: jsonData, to: [String: Any]()) }
     return convertedDict
   }
 }

--- a/Projects/Shared/Utility/Sources/Extensions/Encodable+.swift
+++ b/Projects/Shared/Utility/Sources/Extensions/Encodable+.swift
@@ -1,0 +1,18 @@
+//
+//  Encodable+.swift
+//  Utility
+//
+//  Created by 조용인 on 3/14/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public extension Encodable {
+  func toDictionary() throws -> [String: Any] {
+    let data = try JSONEncoder().encode(self)
+    let jsonData = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
+    guard let convertedDict = jsonData as? [String: Any] else { throw NSError(domain: "Encodable", code: 0, userInfo: nil) } // TODO: FoundationError로 변경
+    return convertedDict
+  }
+}

--- a/Projects/Shared/Utility/Sources/Extensions/URL+.swift
+++ b/Projects/Shared/Utility/Sources/Extensions/URL+.swift
@@ -1,0 +1,28 @@
+//
+//  URL+.swift
+//  Utility
+//
+//  Created by 조용인 on 3/14/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public extension URL {
+  func appendingPath(_ path: String?) throws -> URL {
+    guard let path = path else { throw NSError(domain: "CLNetworker", code: 0, userInfo: nil) } // TODO: FoundationError로 변경
+    return self.appendingPathComponent(path)
+  }
+  
+  func appendingQueries(_ rawQuery: Encodable?) throws -> URL {
+    guard let rawQuery = rawQuery else { throw NSError(domain: "CLNetworker", code: 0, userInfo: nil) } // TODO: FoundationError로 변경
+    let encodedQuery = try rawQuery.toDictionary()
+    let queries = encodedQuery.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
+    guard var components = URLComponents(url: self, resolvingAgainstBaseURL: true) else {
+      throw NSError(domain: "CLNetworker", code: 0, userInfo: nil) // TODO: FoundationError로 변경
+    }
+    components.queryItems = queries
+    guard let urlWithQueries = components.url else { throw NSError(domain: "CLNetworker", code: 0, userInfo: nil) } // TODO: FoundationError로 변경
+    return urlWithQueries
+  }
+}

--- a/Projects/Shared/Utility/Sources/Extensions/URL+.swift
+++ b/Projects/Shared/Utility/Sources/Extensions/URL+.swift
@@ -10,19 +10,19 @@ import Foundation
 
 public extension URL {
   func appendingPath(_ path: String?) throws -> URL {
-    guard let path = path else { throw NSError(domain: "CLNetworker", code: 0, userInfo: nil) } // TODO: FoundationError로 변경
+    guard let path = path else { throw FoundationError.thisValueIsNil(path) }
     return self.appendingPathComponent(path)
   }
   
   func appendingQueries(_ rawQuery: Encodable?) throws -> URL {
-    guard let rawQuery = rawQuery else { throw NSError(domain: "CLNetworker", code: 0, userInfo: nil) } // TODO: FoundationError로 변경
+    guard let rawQuery = rawQuery else { throw FoundationError.thisValueIsNil(rawQuery) }
     let encodedQuery = try rawQuery.toDictionary()
     let queries = encodedQuery.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
     guard var components = URLComponents(url: self, resolvingAgainstBaseURL: true) else {
-      throw NSError(domain: "CLNetworker", code: 0, userInfo: nil) // TODO: FoundationError로 변경
+      throw FoundationError.failedToCreateURLComponents
     }
     components.queryItems = queries
-    guard let urlWithQueries = components.url else { throw NSError(domain: "CLNetworker", code: 0, userInfo: nil) } // TODO: FoundationError로 변경
+    guard let urlWithQueries = components.url else { throw FoundationError.thisValueIsNil(components.url) }
     return urlWithQueries
   }
 }

--- a/Projects/Shared/Utility/Sources/Extensions/URLRequest+.swift
+++ b/Projects/Shared/Utility/Sources/Extensions/URLRequest+.swift
@@ -1,0 +1,31 @@
+//
+//  URLRequest+.swift
+//  Utility
+//
+//  Created by 조용인 on 3/14/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public extension URLRequest {
+  func setMethod(_ method: String) -> URLRequest {
+    var urlRequest = self
+    urlRequest.httpMethod = method
+    return urlRequest
+  }
+  
+  func appendingHeaders(_ headers: [String: String]) -> URLRequest {
+    var urlRequest = self
+    headers.forEach { urlRequest.addValue($1, forHTTPHeaderField: $0) }
+    return urlRequest
+  }
+  
+  func setBody(_ body: Encodable?, encoder: JSONEncoder = JSONEncoder()) throws -> URLRequest {
+    var urlRequest = self
+    guard let body = body else { throw NSError(domain: "CLNetworker", code: 0, userInfo: nil) } // TODO: FoundationError로 변경
+    guard let data = try? encoder.encode(body) else { throw NSError(domain: "CLNetworker", code: 0, userInfo: nil) } // TODO: FoundationError로 변경
+    urlRequest.httpBody = data
+    return urlRequest
+  }
+}

--- a/Projects/Shared/Utility/Sources/Extensions/URLRequest+.swift
+++ b/Projects/Shared/Utility/Sources/Extensions/URLRequest+.swift
@@ -23,8 +23,8 @@ public extension URLRequest {
   
   func setBody(_ body: Encodable?, encoder: JSONEncoder = JSONEncoder()) throws -> URLRequest {
     var urlRequest = self
-    guard let body = body else { throw NSError(domain: "CLNetworker", code: 0, userInfo: nil) } // TODO: FoundationError로 변경
-    guard let data = try? encoder.encode(body) else { throw NSError(domain: "CLNetworker", code: 0, userInfo: nil) } // TODO: FoundationError로 변경
+    guard let body = body else { throw FoundationError.invalidBody }
+    guard let data = try? encoder.encode(body) else { throw FoundationError.failedToEncode}
     urlRequest.httpBody = data
     return urlRequest
   }

--- a/Projects/Shared/Utility/Sources/source.swift
+++ b/Projects/Shared/Utility/Sources/source.swift
@@ -1,1 +1,0 @@
-// add logic


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #4 

## 🔎 작업 내용
- Network 인터페이스 구성
- Network 구현체 구현
- Foundation 레벨의 Error 타입 구현
- Network 레벨의 Error 타입 구현
- Swift 6.0 대응을 위한 일관적인 Sendable 준수
## 📷 스크린샷

## 🛠️ 기타 공유 내용
- Network의 execute의 경우, 중간 취소가 가능한 케이스와 일반적인 실행 함수 2가지로 구분이 됩니다.
- 중간취소가 가능한 경우는, 사용자가 네트워크 요청 중 특정 state에 따른 Network Task의 cancel을 요청하게 되면 내장된 프로세스에 따라 Task가 중단되게 됩니다.
- 또한, execute에 timeout값을 추가하여 네트워크적 스트레스가 있는 상태에서 timeout 처리가 가능하도록 구현하였습니다.

+ 추후, 필요에 따라 인터셉터 로직을 구현 예정
