### PR TITLE
Text LineHeight 설정

### DIFF
--- a/Projects/Core/DesignKit/Sources/Component/NavigationBar/NavigationBar.swift
+++ b/Projects/Core/DesignKit/Sources/Component/NavigationBar/NavigationBar.swift
@@ -37,7 +37,7 @@ public struct NavigationBar<BackContent: View, CloseContent: View>: View {
       Spacer()
       if let title = title {
         Text(title)
-          .font(FontSet.Title.title3)
+          .fontStyle(FontStyle.Title.title3)
           .foregroundStyle(ColorSet.Text.Primary)
       }
       Spacer()

--- a/Projects/Core/DesignKit/Sources/Component/NavigationBar/NavigationBar.swift
+++ b/Projects/Core/DesignKit/Sources/Component/NavigationBar/NavigationBar.swift
@@ -37,7 +37,7 @@ public struct NavigationBar<BackContent: View, CloseContent: View>: View {
       Spacer()
       if let title = title {
         Text(title)
-          .fontStyle(FontStyle.Title.title3)
+          .fontStyle(FontSet.Title.title3)
           .foregroundStyle(ColorSet.Text.Primary)
       }
       Spacer()

--- a/Projects/Core/DesignKit/Sources/Component/PIDATextField/PIDATextField.swift
+++ b/Projects/Core/DesignKit/Sources/Component/PIDATextField/PIDATextField.swift
@@ -31,13 +31,13 @@ public struct PIDATextField: View {
       if text.isEmpty {
         Text(placeholder)
           .foregroundColor(ColorSet.Text.Tertiary)
-          .fontStyle(FontStyle.Body.body2)
+          .fontStyle(FontSet.Body.body2)
       }
       
       TextField("", text: $text)
         .focused($internalFocus)
         .foregroundColor(ColorSet.Text.Primary)
-        .fontStyle(FontStyle.Body.body2)
+        .fontStyle(FontSet.Body.body2)
         .tint(ColorSet.Component.Primary)
         .onSubmit {
           onSubmit?()

--- a/Projects/Core/DesignKit/Sources/Component/PIDATextField/PIDATextField.swift
+++ b/Projects/Core/DesignKit/Sources/Component/PIDATextField/PIDATextField.swift
@@ -31,13 +31,13 @@ public struct PIDATextField: View {
       if text.isEmpty {
         Text(placeholder)
           .foregroundColor(ColorSet.Text.Tertiary)
-          .font(FontSet.Body.body2)
+          .fontStyle(FontStyle.Body.body2)
       }
       
       TextField("", text: $text)
         .focused($internalFocus)
         .foregroundColor(ColorSet.Text.Primary)
-        .font(FontSet.Body.body2)
+        .fontStyle(FontStyle.Body.body2)
         .tint(ColorSet.Component.Primary)
         .onSubmit {
           onSubmit?()

--- a/Projects/Core/DesignKit/Sources/Component/PIDAlert/PIDAlert.swift
+++ b/Projects/Core/DesignKit/Sources/Component/PIDAlert/PIDAlert.swift
@@ -63,13 +63,13 @@ public struct PIDAlert: View {
   private var titleView: some View {
     VStack(spacing: .Number8) {
       Text(title)
-        .fontStyle(FontStyle.Title.title2)
+        .fontStyle(FontSet.Title.title2)
         .foregroundStyle(ColorSet.Text.Primary)
         .multilineTextAlignment(.center)
       
       if let message = message {
         Text(message)
-          .fontStyle(FontStyle.Body.body3)
+          .fontStyle(FontSet.Body.body3)
           .foregroundStyle(ColorSet.Text.Secondary)
           .multilineTextAlignment(.center)
       }

--- a/Projects/Core/DesignKit/Sources/Component/PIDAlert/PIDAlert.swift
+++ b/Projects/Core/DesignKit/Sources/Component/PIDAlert/PIDAlert.swift
@@ -63,13 +63,13 @@ public struct PIDAlert: View {
   private var titleView: some View {
     VStack(spacing: .Number8) {
       Text(title)
-        .font(FontSet.Title.title2)
+        .fontStyle(FontStyle.Title.title2)
         .foregroundStyle(ColorSet.Text.Primary)
         .multilineTextAlignment(.center)
       
       if let message = message {
         Text(message)
-          .font(FontSet.Body.body3)
+          .fontStyle(FontStyle.Body.body3)
           .foregroundStyle(ColorSet.Text.Secondary)
           .multilineTextAlignment(.center)
       }

--- a/Projects/Core/DesignKit/Sources/Component/PIDButton/PIDButton.swift
+++ b/Projects/Core/DesignKit/Sources/Component/PIDButton/PIDButton.swift
@@ -79,7 +79,7 @@ public struct PIDButton<IconContent: View>: View {
           ? ColorSet.Text.Disabled
           : isSecondary ? ColorSet.Text.Primary : ColorSet.Text.Inverse
         )
-        .font(size.font)
+        .fontStyle(size.font)
     }
     .frame(maxWidth: .infinity)
     .padding(.vertical, size.padding.vertical)

--- a/Projects/Core/DesignKit/Sources/Component/PIDButton/PIDButtonSize.swift
+++ b/Projects/Core/DesignKit/Sources/Component/PIDButton/PIDButtonSize.swift
@@ -29,9 +29,9 @@ public enum PIDButtonSize {
   
   public var font: FontInfo {
     switch self {
-    case .large: return FontStyle.Label.label1
-    case .medium: return FontStyle.Label.label2
-    case .small: return FontStyle.Label.label3
+    case .large: return FontSet.Label.label1
+    case .medium: return FontSet.Label.label2
+    case .small: return FontSet.Label.label3
     }
   }
 }

--- a/Projects/Core/DesignKit/Sources/Component/PIDButton/PIDButtonSize.swift
+++ b/Projects/Core/DesignKit/Sources/Component/PIDButton/PIDButtonSize.swift
@@ -27,11 +27,11 @@ public enum PIDButtonSize {
     }
   }
   
-  public var font: Font {
+  public var font: FontInfo {
     switch self {
-    case .large: return FontSet.Label.label1
-    case .medium: return FontSet.Label.label2
-    case .small: return FontSet.Label.label3
+    case .large: return FontStyle.Label.label1
+    case .medium: return FontStyle.Label.label2
+    case .small: return FontStyle.Label.label3
     }
   }
 }

--- a/Projects/Core/DesignKit/Sources/Component/SearchBar/SearchBar.swift
+++ b/Projects/Core/DesignKit/Sources/Component/SearchBar/SearchBar.swift
@@ -60,7 +60,7 @@ public struct SearchBar<LeadingContent: View, TrailingContent: View>: View {
       searchIconView
       Text(placeholder)
         .foregroundColor(ColorSet.Text.Tertiary)
-        .font(FontSet.Body.body2)
+        .fontStyle(FontStyle.Body.body2)
       Spacer()
       trailingContent?()
     }
@@ -110,7 +110,7 @@ public struct SearchBar<LeadingContent: View, TrailingContent: View>: View {
       leadingContent?()
       Text(text)
         .foregroundColor(ColorSet.Text.Primary)
-        .font(FontSet.Body.body2)
+        .fontStyle(FontStyle.Body.body2)
       Spacer()
       trailingContent?()
     }

--- a/Projects/Core/DesignKit/Sources/Component/SearchBar/SearchBar.swift
+++ b/Projects/Core/DesignKit/Sources/Component/SearchBar/SearchBar.swift
@@ -60,7 +60,7 @@ public struct SearchBar<LeadingContent: View, TrailingContent: View>: View {
       searchIconView
       Text(placeholder)
         .foregroundColor(ColorSet.Text.Tertiary)
-        .fontStyle(FontStyle.Body.body2)
+        .fontStyle(FontSet.Body.body2)
       Spacer()
       trailingContent?()
     }
@@ -110,7 +110,7 @@ public struct SearchBar<LeadingContent: View, TrailingContent: View>: View {
       leadingContent?()
       Text(text)
         .foregroundColor(ColorSet.Text.Primary)
-        .fontStyle(FontStyle.Body.body2)
+        .fontStyle(FontSet.Body.body2)
       Spacer()
       trailingContent?()
     }

--- a/Projects/Core/DesignKit/Sources/Modifier/FontStyleModifier.swift
+++ b/Projects/Core/DesignKit/Sources/Modifier/FontStyleModifier.swift
@@ -1,0 +1,30 @@
+//
+//  FontStyleModifier.swift
+//  DesignKit
+//
+//  Created by Jiyeon on 3/25/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import SwiftUI
+
+public struct FontStyleModifier: ViewModifier {
+  var font: FontInfo
+  init(font: FontInfo) {
+    self.font = font
+  }
+  
+  public func body(content: Content) -> some View {
+    content
+      .font(font.font)
+      .lineSpacing(font.lineSpacing)
+      .padding(.vertical, font.lineSpacing)
+  }
+}
+
+extension View {
+  public func fontStyle(_ font: FontInfo) -> some View {
+    self.modifier(FontStyleModifier(font: font))
+  }
+}
+

--- a/Projects/Core/DesignKit/Sources/Modifier/FontStyleModifier.swift
+++ b/Projects/Core/DesignKit/Sources/Modifier/FontStyleModifier.swift
@@ -17,7 +17,7 @@ public struct FontStyleModifier: ViewModifier {
   public func body(content: Content) -> some View {
     content
       .font(font.font)
-      .padding(.vertical, font.lineSpacing/2)
+      .padding(.vertical, font.lineheight/2)
   }
 }
 

--- a/Projects/Core/DesignKit/Sources/Modifier/FontStyleModifier.swift
+++ b/Projects/Core/DesignKit/Sources/Modifier/FontStyleModifier.swift
@@ -17,8 +17,7 @@ public struct FontStyleModifier: ViewModifier {
   public func body(content: Content) -> some View {
     content
       .font(font.font)
-      .lineSpacing(font.lineSpacing)
-      .padding(.vertical, font.lineSpacing)
+      .padding(.vertical, font.lineSpacing/2)
   }
 }
 

--- a/Projects/Core/DesignKit/Sources/Resource+/Font+.swift
+++ b/Projects/Core/DesignKit/Sources/Resource+/Font+.swift
@@ -8,45 +8,9 @@
 
 import Foundation
 import SwiftUI
+
 extension DesignKitFontFamily {
   public struct FontSet: Sendable {
-    public struct Heading: Sendable {
-      public static let heading1 =  DesignKitFontFamily.Pretendard.semiBold.swiftUIFont(size: 24)
-      public static let heading2 =  DesignKitFontFamily.Pretendard.semiBold.swiftUIFont(size: 20)
-      public static let heading3 =  DesignKitFontFamily.Pretendard.semiBold.swiftUIFont(size: 18)
-      public static let heading4 =  DesignKitFontFamily.Pretendard.semiBold.swiftUIFont(size: 16)
-    }
-    
-    public struct Title: Sendable {
-      public static let title1 = DesignKitFontFamily.Pretendard.semiBold.swiftUIFont(size: 20)
-      public static let title2 = DesignKitFontFamily.Pretendard.semiBold.swiftUIFont(size: 18)
-      public static let title3 = DesignKitFontFamily.Pretendard.semiBold.swiftUIFont(size: 16)
-      public static let title4 = DesignKitFontFamily.Pretendard.semiBold.swiftUIFont(size: 14)
-      public static let title5 = DesignKitFontFamily.Pretendard.semiBold.swiftUIFont(size: 12)
-    }
-    
-    public struct Body: Sendable {
-      public static let body1 = DesignKitFontFamily.Pretendard.regular.swiftUIFont(size: 18)
-      public static let body2 = DesignKitFontFamily.Pretendard.regular.swiftUIFont(size: 16)
-      public static let body3 = DesignKitFontFamily.Pretendard.medium.swiftUIFont(size: 14)
-    }
-    
-    public struct Caption: Sendable {
-      public static let caption1 = DesignKitFontFamily.Pretendard.medium.swiftUIFont(size: 12)
-      public static let caption2 = DesignKitFontFamily.Pretendard.medium.swiftUIFont(size: 8)
-    }
-    
-    public struct Label: Sendable {
-      public static let label1 = DesignKitFontFamily.Pretendard.semiBold.swiftUIFont(size: 16)
-      public static let label2 = DesignKitFontFamily.Pretendard.semiBold.swiftUIFont(size: 14)
-      public static let label3 = DesignKitFontFamily.Pretendard.semiBold.swiftUIFont(size: 12)
-    }
-  }
-}
-
-
-extension DesignKitFontFamily {
-  public struct FontStyle: Sendable {
     public struct Heading: Sendable {
       public static let heading1 = FontInfo(font: Pretendard.semiBold, size: 24, lineHeight: 1.4)
       public static let heading2 = FontInfo(font: Pretendard.semiBold, size: 20, lineHeight: 1.4)
@@ -84,11 +48,11 @@ extension DesignKitFontFamily {
 public struct FontInfo: Sendable {
   public let font: Font
   public let size: CGFloat
-  public var lineSpacing: CGFloat
+  public var lineheight: CGFloat
   
   public init(font: DesignKitFontConvertible, size: CGFloat, lineHeight: CGFloat) {
     self.font = font.swiftUIFont(size: size)
-    self.lineSpacing = (size * lineHeight - size) / 2
+    self.lineheight = (size * lineHeight - size) / 2
     self.size = size
   }
 }

--- a/Projects/Core/DesignKit/Sources/Resource+/Font+.swift
+++ b/Projects/Core/DesignKit/Sources/Resource+/Font+.swift
@@ -43,3 +43,52 @@ extension DesignKitFontFamily {
     }
   }
 }
+
+
+extension DesignKitFontFamily {
+  public struct FontStyle: Sendable {
+    public struct Heading: Sendable {
+      public static let heading1 = FontInfo(font: Pretendard.semiBold, size: 24, lineHeight: 1.4)
+      public static let heading2 = FontInfo(font: Pretendard.semiBold, size: 20, lineHeight: 1.4)
+      public static let heading3 = FontInfo(font: Pretendard.semiBold, size: 18, lineHeight: 1.4)
+      public static let heading4 = FontInfo(font: Pretendard.semiBold, size: 16, lineHeight: 1.4)
+    }
+    
+    public struct Title: Sendable {
+      public static let title1 = FontInfo(font: Pretendard.semiBold, size: 20, lineHeight: 1.5)
+      public static let title2 = FontInfo(font: Pretendard.semiBold, size: 18, lineHeight: 1.5)
+      public static let title3 = FontInfo(font: Pretendard.semiBold, size: 16, lineHeight: 1.5)
+      public static let title4 = FontInfo(font: Pretendard.semiBold, size: 14, lineHeight: 1.5)
+      public static let title5 = FontInfo(font: Pretendard.semiBold, size: 12, lineHeight: 1.5)
+    }
+    
+    public struct Body: Sendable {
+      public static let body1 = FontInfo(font: Pretendard.regular, size: 18, lineHeight: 1.5)
+      public static let body2 = FontInfo(font: Pretendard.regular, size: 16, lineHeight: 1.5)
+      public static let body3 = FontInfo(font: Pretendard.medium, size: 14, lineHeight: 1.5)
+    }
+    
+    public struct Caption: Sendable {
+      public static let caption1 = FontInfo(font: Pretendard.medium, size: 12, lineHeight: 1.5)
+      public static let caption2 = FontInfo(font: Pretendard.medium, size: 8, lineHeight: 1.6)
+    }
+    
+    public struct Label: Sendable {
+      public static let label1 = FontInfo(font: Pretendard.semiBold, size: 16, lineHeight: 1.5)
+      public static let label2 = FontInfo(font: Pretendard.semiBold, size: 14, lineHeight: 1.5)
+      public static let label3 = FontInfo(font: Pretendard.semiBold, size: 12, lineHeight: 1.5)
+    }
+  }
+}
+
+public struct FontInfo: Sendable {
+  public let font: Font
+  public let size: CGFloat
+  public var lineSpacing: CGFloat
+  
+  public init(font: DesignKitFontConvertible, size: CGFloat, lineHeight: CGFloat) {
+    self.font = font.swiftUIFont(size: size)
+    self.lineSpacing = (size * lineHeight - size) / 2
+    self.size = size
+  }
+}

--- a/Projects/Core/DesignKit/Sources/Resource+/Size+.swift
+++ b/Projects/Core/DesignKit/Sources/Resource+/Size+.swift
@@ -27,9 +27,6 @@ public extension CGFloat {
   static let Number48: CGFloat = 48
   static let Number56: CGFloat = 56
   static let Number64: CGFloat = 64
-  static let Number66: CGFloat = 66
-  static let Number68: CGFloat = 68
-  static let Number76: CGFloat = 76
   static let Number80: CGFloat = 80
   static let Number100: CGFloat = 100
   static let Number320: CGFloat = 320

--- a/Projects/Core/DesignKit/Sources/Resource+/Typealias+.swift
+++ b/Projects/Core/DesignKit/Sources/Resource+/Typealias+.swift
@@ -8,6 +8,5 @@
 
 import Foundation
 
-public typealias FontSet = DesignKitFontFamily.FontSet
 public typealias ColorSet = DesignKitAsset.ColorSet
-public typealias FontStyle = DesignKitFontFamily.FontStyle
+public typealias FontSet = DesignKitFontFamily.FontSet

--- a/Projects/Core/DesignKit/Sources/Resource+/Typealias+.swift
+++ b/Projects/Core/DesignKit/Sources/Resource+/Typealias+.swift
@@ -10,3 +10,4 @@ import Foundation
 
 public typealias FontSet = DesignKitFontFamily.FontSet
 public typealias ColorSet = DesignKitAsset.ColorSet
+public typealias FontStyle = DesignKitFontFamily.FontStyle

--- a/Projects/Features/Search/SearchFeatureInterface/Sources/Components/SearchResultList.swift
+++ b/Projects/Features/Search/SearchFeatureInterface/Sources/Components/SearchResultList.swift
@@ -36,21 +36,20 @@ public struct SearchResultList: View {
   public var body: some View {
     VStack {
       HStack {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: .Number0) {
           Text(roadName)
-            .font(FontSet.Body.body2)
+            .fontStyle(FontStyle.Body.body2)
             .foregroundStyle(ColorSet.Text.Primary)
           Text(address)
-            .font(FontSet.Caption.caption1)
+            .fontStyle(FontStyle.Caption.caption1)
             .foregroundStyle(ColorSet.Text.Tertiary)
         }
         Spacer()
         Text(subInfo)
-          .font(FontSet.Caption.caption1)
+          .fontStyle(FontStyle.Caption.caption1)
           .foregroundStyle(ColorSet.Text.Tertiary)
       }
-      .frame(height: .Number66)
-      
+      .padding(.vertical, .Number12)
       BorderView(size: .long)
     }
     .contentShape(Rectangle())

--- a/Projects/Features/Search/SearchFeatureInterface/Sources/Components/SearchResultList.swift
+++ b/Projects/Features/Search/SearchFeatureInterface/Sources/Components/SearchResultList.swift
@@ -38,15 +38,15 @@ public struct SearchResultList: View {
       HStack {
         VStack(alignment: .leading, spacing: .Number0) {
           Text(roadName)
-            .fontStyle(FontStyle.Body.body2)
+            .fontStyle(FontSet.Body.body2)
             .foregroundStyle(ColorSet.Text.Primary)
           Text(address)
-            .fontStyle(FontStyle.Caption.caption1)
+            .fontStyle(FontSet.Caption.caption1)
             .foregroundStyle(ColorSet.Text.Tertiary)
         }
         Spacer()
         Text(subInfo)
-          .fontStyle(FontStyle.Caption.caption1)
+          .fontStyle(FontSet.Caption.caption1)
           .foregroundStyle(ColorSet.Text.Tertiary)
       }
       .padding(.vertical, .Number12)

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingList/SettingItemListView.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingList/SettingItemListView.swift
@@ -34,7 +34,7 @@ struct SettingItemListView: View {
   @ViewBuilder
   private func sectionTitle(_ title: String) -> some View {
     Text(title)
-      .fontStyle(FontStyle.Body.body3)
+      .fontStyle(FontSet.Body.body3)
       .foregroundStyle(ColorSet.Text.Secondary)
       .padding(.top, .Number8)
       .padding(.bottom, .Number4)

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingList/SettingItemListView.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingList/SettingItemListView.swift
@@ -34,7 +34,7 @@ struct SettingItemListView: View {
   @ViewBuilder
   private func sectionTitle(_ title: String) -> some View {
     Text(title)
-      .font(FontSet.Body.body3)
+      .fontStyle(FontStyle.Body.body3)
       .foregroundStyle(ColorSet.Text.Secondary)
       .padding(.top, .Number8)
       .padding(.bottom, .Number4)

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingList/SettingItemView.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingList/SettingItemView.swift
@@ -21,26 +21,26 @@ struct SettingItemView: View {
   
   var body: some View {
     HStack {
-      VStack(alignment: .leading, spacing: item.subtitle == nil ? .Number0 : .Number4) {
+      VStack(alignment: .leading, spacing: .Number2) {
         Text(item.title)
-          .font(FontSet.Body.body2)
+          .fontStyle(FontStyle.Body.body2)
           .foregroundStyle(ColorSet.Text.Primary)
         if let subtitle = item.subtitle {
           Text(subtitle)
-            .font(FontSet.Caption.caption1)
+            .fontStyle(FontStyle.Caption.caption1)
+            .lineSpacing(20)
             .foregroundStyle(ColorSet.Text.Tertiary)
         }
       }
       Spacer()
       if let trailingText = item.trailing {
         Text(trailingText)
-          .font(FontSet.Label.label2)
+          .fontStyle(FontStyle.Label.label2)
           .foregroundStyle(ColorSet.Text.Accent)
       }
     }
     .padding(.vertical, .Number12)
     .padding(.horizontal, .Number16)
-    .frame(height: item.subtitle == nil ? .Number48 : .Number68)
     .contentShape(Rectangle())
     .onTapGesture {
       if let action = action {

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingList/SettingItemView.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingList/SettingItemView.swift
@@ -23,11 +23,11 @@ struct SettingItemView: View {
     HStack {
       VStack(alignment: .leading, spacing: .Number2) {
         Text(item.title)
-          .fontStyle(FontStyle.Body.body2)
+          .fontStyle(FontSet.Body.body2)
           .foregroundStyle(ColorSet.Text.Primary)
         if let subtitle = item.subtitle {
           Text(subtitle)
-            .fontStyle(FontStyle.Caption.caption1)
+            .fontStyle(FontSet.Caption.caption1)
             .lineSpacing(20)
             .foregroundStyle(ColorSet.Text.Tertiary)
         }
@@ -35,7 +35,7 @@ struct SettingItemView: View {
       Spacer()
       if let trailingText = item.trailing {
         Text(trailingText)
-          .fontStyle(FontStyle.Label.label2)
+          .fontStyle(FontSet.Label.label2)
           .foregroundStyle(ColorSet.Text.Accent)
       }
     }

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingView.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingView.swift
@@ -82,7 +82,7 @@ extension SettingView {
       } else {
         HStack(spacing: .Number0) {
           Text("로그인 하기")
-            .fontStyle(FontStyle.Body.body2)
+            .fontStyle(FontSet.Body.body2)
           
           Icon(image: .chevronRight)
             .size(.extraLarge)
@@ -90,7 +90,7 @@ extension SettingView {
       }
       Spacer()
     }
-    .fontStyle(FontStyle.Body.body2)
+    .fontStyle(FontSet.Body.body2)
     .foregroundStyle(ColorSet.Text.Primary)
     .padding(.Number16)
     .onTapGesture {
@@ -105,11 +105,11 @@ extension SettingView {
       
       VStack(alignment: .leading, spacing: .Number2) {
         Text("피드백 남기러 가기")
-          .fontStyle(FontStyle.Title.title3)
+          .fontStyle(FontSet.Title.title3)
           .foregroundStyle(ColorSet.Text.Primary)
 
         Text("좋은 점, 개선할 점, 궁금한 점 의견을 들려주세요!")
-          .fontStyle(FontStyle.Caption.caption1)
+          .fontStyle(FontSet.Caption.caption1)
           .foregroundStyle(ColorSet.Text.Secondary)
       }
       Spacer()

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingView.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingView.swift
@@ -76,15 +76,13 @@ extension SettingView {
   private var profileView: some View {
     HStack(alignment: .center, spacing: .Number16) {
       Image(asset: ImageSet.avatarLarge.swiftUIImage)
-        .resizable()
-        .frame(width: .Number40, height: .Number40)
       
       if store.isLoggedIn, let username = store.username {
         Text("환영해요! \(username)님")
       } else {
         HStack(spacing: .Number0) {
           Text("로그인 하기")
-            .font(FontSet.Body.body2)
+            .fontStyle(FontStyle.Body.body2)
           
           Icon(image: .chevronRight)
             .size(.extraLarge)
@@ -92,7 +90,7 @@ extension SettingView {
       }
       Spacer()
     }
-    .font(FontSet.Body.body2)
+    .fontStyle(FontStyle.Body.body2)
     .foregroundStyle(ColorSet.Text.Primary)
     .padding(.Number16)
     .onTapGesture {
@@ -104,16 +102,14 @@ extension SettingView {
   private var feedBackView: some View {
     HStack(spacing: .Number12) {
       Image(asset: ImageSet.loveletter.swiftUIImage)
-        .resizable()
-        .frame(width: .Number40, height: .Number40)
       
       VStack(alignment: .leading, spacing: .Number2) {
         Text("피드백 남기러 가기")
-          .font(FontSet.Title.title3)
+          .fontStyle(FontStyle.Title.title3)
           .foregroundStyle(ColorSet.Text.Primary)
 
         Text("좋은 점, 개선할 점, 궁금한 점 의견을 들려주세요!")
-          .font(FontSet.Caption.caption1)
+          .fontStyle(FontStyle.Caption.caption1)
           .foregroundStyle(ColorSet.Text.Secondary)
       }
       Spacer()


### PR DESCRIPTION

## 🔎 작업 내용
- 줄 간격 설정
- FontSet의 프로퍼티를 FontInfo 타입으로 적용하여 폰트, 폰트 크기, 줄간격 정보를 가지고 있도록 수정
- .fontStyle modifier 추가
- 변경사항 전체 적용

## 사용 예시
기존에 사용하던 FontSet typealias 그대로 사용하되, font를 적용할 때 CustomModifier인 `.fontStyle`을 사용합니다.
```swift
Text("로그아웃")
  .fontStyle(FontSet.Body.body1)
```

## 📷 스크린샷
|수정 전|수정 후|
|:----:|:----:|
|<img src = "https://github.com/user-attachments/assets/1860c7a0-f641-4378-8580-d9a523ee2b60" width = "300">|<img src = "https://github.com/user-attachments/assets/4dd29a54-cc5e-4060-885b-59594bbdbe19" width = "300">|


## 🛠️ 기타 공유 내용
줄 간격이 `폰트 크기 * 비율 - 폰트 크기` 로 해서 추가되어야 하는 크기를 계산하고, 2로 나누어 글자 사이에 들어가야 하는 값으로 계산했습니다.
`.linespacing`이 적용이 안돼서 `.padding(.vertical, )`으로 간격을 추가했습니다. 그래서 그런지 줄 간격이 너무 크게 잡혀서 2로 한 번 더 나누니 얼추 비슷하게 적용이 됩니다...
줄 간격이 적용되는 구조가 복잡한 것 같은데, 이걸 다 계산하기엔 다른 작업이 더 급해서 이정도로 마무리 합니다..

