### PR TITLE
회원 조회 및 수정, 로그아웃, 탈퇴 구현

### DIFF
--- a/Projects/Core/Networker/Sources/Implement/Networker.swift
+++ b/Projects/Core/Networker/Sources/Implement/Networker.swift
@@ -32,7 +32,7 @@ public struct Networker: NetworkProtocol, Sendable {
       
       group.addTask { // 타임아웃 체크 전용 Task
         try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-        throw NetworkError.timeout(timeout)
+        throw throwError(NetworkError.timeout(timeout), endpoint: endpoint)
       }
       
       do {
@@ -40,11 +40,17 @@ public struct Networker: NetworkProtocol, Sendable {
           group.cancelAll()
           return result
         } else {
-          throw FoundationError.taskFailed
+          throw throwError(
+            FoundationError.taskFailed,
+            endpoint: endpoint
+          )
         }
       } catch {
         group.cancelAll()
-        throw FoundationError.taskCancelled
+        throw throwError(
+          FoundationError.taskCancelled,
+          endpoint: endpoint
+        )
       }
     }
   }
@@ -69,7 +75,10 @@ public struct Networker: NetworkProtocol, Sendable {
         
         group.addTask { // 타임아웃 태스크
           try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-          throw NetworkError.timeout(timeout)
+          throw throwError(
+            NetworkError.timeout(timeout),
+            endpoint: endpoint
+          )
         }
         
         do {
@@ -77,7 +86,10 @@ public struct Networker: NetworkProtocol, Sendable {
             group.cancelAll()
             return result
           } else {
-            throw FoundationError.taskFailed
+            throw throwError(
+              FoundationError.taskFailed,
+              endpoint: endpoint
+            )
           }
         } catch {
           group.cancelAll()
@@ -96,26 +108,75 @@ extension Networker {
   ) throws -> R {
     
     guard let httpResponse = response as? HTTPURLResponse else {
-      throw  FoundationError.failedToCasting(from: URLResponse.self, to: HTTPURLResponse.self)
+      throw throwError(
+        FoundationError.failedToCasting(
+          from: URLResponse.self,
+          to: HTTPURLResponse.self
+        ),
+        endpoint: endpoint
+      )
     }
     
     guard (200..<300).contains(httpResponse.statusCode) else {
-      let error = try JSONDecoder().decode(ErrorResponse.self, from: data)
+      let errorResponse = try JSONDecoder().decode(ErrorResponse.self, from: data)
       switch httpResponse.statusCode {
-      case 400...599: throw NetworkError.serverError(
-        message: error.message,
-        code: httpResponse.statusCode
-      )
-      default: throw NetworkError.invalidStatusCode(httpResponse.statusCode)
+      case 400...599:
+        throw throwError(
+          NetworkError.serverError(
+            message: errorResponse.message,
+            code: httpResponse.statusCode
+          ),
+          endpoint: endpoint
+        )
+      default:
+        throw throwError(
+          NetworkError.invalidStatusCode(
+            httpResponse.statusCode
+          ),
+          endpoint: endpoint
+        )
       }
     }
     
     do {
       let decoder = JSONDecoder()
       let response = try decoder.decode(APIResponse<R>.self, from: data)
+      responseSuccess(response, endpoint: endpoint)
       return response.data
     } catch {
-      throw FoundationError.failedToDecode(data)
+      throw throwError(
+        FoundationError.failedToDecode(data),
+        endpoint: endpoint
+      )
     }
+  }
+}
+
+extension Networker {
+  fileprivate func responseSuccess<R>(_ response: APIResponse<R>, endpoint: any APIRequestable) {
+    print("""
+          ==========================================
+          ============== ✅ SUCCESS ================
+          ✔️ URL: \(endpoint.path)
+          ✔️ Data: \(response.data)
+          ==========================================
+          """)
+  }
+  
+  fileprivate func throwError(_ error: Error, endpoint: any APIRequestable) -> Error {
+    var description: String = error.localizedDescription
+    if let error = error as? NetworkError {
+      description = error.errorDescription
+    } else if let error = error as? FoundationError {
+      description = error.errorDescription
+    }
+    print("""
+          =========================================
+          ============== 🚨 ERROR==================
+          ✔️ URL: \(endpoint.path)
+          ✔️ Message: \(description)
+          =========================================
+          """)
+    return error
   }
 }

--- a/Projects/Core/Networker/Sources/Interface/APIRequestable.swift
+++ b/Projects/Core/Networker/Sources/Interface/APIRequestable.swift
@@ -12,6 +12,12 @@ import Utility
 public typealias HTTPHeaders = [String: String]
 public typealias HTTPParameters = [String: Any]
 
+
+public enum APIHeaderType {
+  case plain
+  case authorization(String)
+}
+
 public enum HTTPRequestParameter {
   case query(_ query: Encodable?)
   case body(_ parameter: Encodable?)
@@ -29,7 +35,7 @@ public protocol APIRequestable {
   
   var baseURL: URL? { get }
   var method: HTTPMethod { get }
-  var headers: HTTPHeaders { get }
+  var headers: APIHeaderType { get }
   var path: String { get }
   var parameters: HTTPRequestParameter? { get }
   
@@ -37,11 +43,13 @@ public protocol APIRequestable {
 }
 
 public extension APIRequestable {
+  var headers: APIHeaderType { .plain }
+  
   func toURLRequest() throws -> URLRequest {
     let url = try configureURL()
     var urlRequest = URLRequest(url: url)
       .setMethod(self.method.rawValue)
-      .appendingHeaders(self.headers)
+      .appendingHeaders(configureHeaders())
     if let parameters = self.parameters {
       switch parameters {
       case let .body(body): urlRequest = try urlRequest.setBody(body)
@@ -61,5 +69,17 @@ public extension APIRequestable {
       }
     }
     return url
+  }
+  
+  fileprivate func configureHeaders() -> HTTPHeaders {
+    switch headers {
+    case .plain:
+      return ["Content-Type": "application/json"]
+    case let .authorization(token):
+      return [
+        "Content-Type": "application/json",
+        "Authorization": "Bearer \(token)"
+      ]
+    }
   }
 }

--- a/Projects/Core/Networker/Sources/Interface/Endpoint.swift
+++ b/Projects/Core/Networker/Sources/Interface/Endpoint.swift
@@ -13,14 +13,14 @@ struct EmptyResponse: Codable {}
 public struct Endpoint<R>: APIRequestable where R: Decodable & Sendable {
   public typealias Response = R
   
-  public let headers: HTTPHeaders
+  public let headers: APIHeaderType
   public let method: HTTPMethod
   public let baseURL: URL?
   public let path: String
   public let parameters: HTTPRequestParameter?
   
   public init(
-    headers: HTTPHeaders = ["Content-Type": "application/json"],
+    headers: APIHeaderType = .plain,
     method: HTTPMethod,
     baseURL: String,
     path: String,

--- a/Projects/Data/Auth/AuthData/Sources/AuthRepositoryImpl.swift
+++ b/Projects/Data/Auth/AuthData/Sources/AuthRepositoryImpl.swift
@@ -27,4 +27,9 @@ public struct AuthRepositoryImpl: AuthRepository {
     let endpoint = AuthEndpoint.signUp(body: .init(email: email, name: nickname))
     return try await network.execute(with: endpoint, timeout: 60).toEntity()
   }
+  
+  public func logout(token: String) async throws {
+    let endpoint = AuthEndpoint.logout(body: .init(token: token))
+    return try await network.execute(with: endpoint, timeout: 60).toEntity()
+  }
 }

--- a/Projects/Data/Auth/AuthDataInterface/Sources/DTO/LogoutDTO.swift
+++ b/Projects/Data/Auth/AuthDataInterface/Sources/DTO/LogoutDTO.swift
@@ -1,0 +1,21 @@
+//
+//  LogoutDTO.swift
+//  AuthDataInterface
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import Networker
+
+public struct LogoutDTO: DTO {
+  public typealias Entity = Void
+  let message: String
+  
+  public init(message: String) {
+    self.message = message
+  }
+  
+  public func toEntity() throws -> Void {}
+}

--- a/Projects/Data/Auth/AuthDataInterface/Sources/Endpoint/AuthEndpoint.swift
+++ b/Projects/Data/Auth/AuthDataInterface/Sources/Endpoint/AuthEndpoint.swift
@@ -30,4 +30,13 @@ public struct AuthEndpoint: Sendable {
     )
   }
   
+  public static func logout(body: LogoutBody) -> Endpoint<LogoutDTO> {
+    return Endpoint(
+      method: .post,
+      baseURL: baseURL,
+      path: "/auth/logout",
+      parameters: .body(body)
+    )
+  }
+  
 }

--- a/Projects/Data/Auth/AuthDataInterface/Sources/Parameter/LogoutBody.swift
+++ b/Projects/Data/Auth/AuthDataInterface/Sources/Parameter/LogoutBody.swift
@@ -1,0 +1,16 @@
+//
+//  LogoutBody.swift
+//  AuthDataInterface
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public struct LogoutBody: Encodable {
+  let token: String
+  public init(token: String) {
+    self.token = token
+  }
+}

--- a/Projects/Data/User/UserData/Project.swift
+++ b/Projects/Data/User/UserData/Project.swift
@@ -1,0 +1,19 @@
+//
+//  UserDataImplementProject.swift
+//
+//  User
+//
+//  Created by JiYeon
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.makeImplementProject(
+  name: "User",
+  layer: .data,
+  implementDependency: [
+    .Data.User.Interface
+  ]
+)
+

--- a/Projects/Data/User/UserData/Sources/UserRepositoryImpl.swift
+++ b/Projects/Data/User/UserData/Sources/UserRepositoryImpl.swift
@@ -1,0 +1,25 @@
+//
+//  UserRepositoryImpl.swift
+//
+//  User
+//
+//  Created by JiYeon
+//
+
+import Foundation
+import UserDataInterface
+import UserDomainInterface
+import Networker
+
+public struct UserRepositoryImpl: UserRepository {
+  private let network: NetworkProtocol
+
+  public init(network: NetworkProtocol) {
+    self.network = network
+  }
+
+  public func fetchUserInfo() async throws -> UserInfoEntity {
+    let endpoint = UserEndPoint.fetchUserInfo()
+    return try await network.execute(with: endpoint, timeout: 60).toEntity()
+  }
+}

--- a/Projects/Data/User/UserData/Sources/UserRepositoryImpl.swift
+++ b/Projects/Data/User/UserData/Sources/UserRepositoryImpl.swift
@@ -22,4 +22,9 @@ public struct UserRepositoryImpl: UserRepository {
     let endpoint = UserEndPoint.fetchUserInfo()
     return try await network.execute(with: endpoint, timeout: 60).toEntity()
   }
+  
+  public func withdraw() async throws {
+    let endpoint = UserEndPoint.withDraw()
+    return try await network.execute(with: endpoint, timeout: 60).toEntity()
+  }
 }

--- a/Projects/Data/User/UserData/Sources/UserRepositoryImpl.swift
+++ b/Projects/Data/User/UserData/Sources/UserRepositoryImpl.swift
@@ -27,4 +27,9 @@ public struct UserRepositoryImpl: UserRepository {
     let endpoint = UserEndPoint.withDraw()
     return try await network.execute(with: endpoint, timeout: 60).toEntity()
   }
+  
+  public func changeNickname(nickname: String) async throws -> UserInfoEntity {
+    let endpoint = UserEndPoint.changeNickname(body: .init(nickname: nickname))
+    return try await network.execute(with: endpoint, timeout: 60).toEntity()
+  }
 }

--- a/Projects/Data/User/UserDataInterface/Project.swift
+++ b/Projects/Data/User/UserDataInterface/Project.swift
@@ -1,0 +1,18 @@
+//
+//  UserDataInterfaceProject.swift
+//
+//  User
+//
+//  Created by JiYeon
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.makeInterfaceProject(
+  name: "User",
+  layer: .data,
+  interfaceDependency: [
+    .Domain.User.Interface
+  ]
+)

--- a/Projects/Data/User/UserDataInterface/Sources/DTO/UserInfoDTO.swift
+++ b/Projects/Data/User/UserDataInterface/Sources/DTO/UserInfoDTO.swift
@@ -1,0 +1,35 @@
+//
+//  UserInfoDTO.swift
+//  UserDataInterface
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import UserDomainInterface
+import Networker
+
+public struct UserInfoDTO: DTO {
+  public typealias Entity = UserInfoEntity
+  let userId: Int
+  let email: String
+  let name: String
+  let nickname: String
+  
+  public init(
+    userId: Int,
+    email: String,
+    name: String,
+    nickname: String
+  ) {
+    self.userId = userId
+    self.email = email
+    self.name = name
+    self.nickname = nickname
+  }
+  
+  public func toEntity() throws -> UserInfoEntity {
+    return .init(userId: userId, nickname: name)
+  }
+}

--- a/Projects/Data/User/UserDataInterface/Sources/DTO/UserInfoDTO.swift
+++ b/Projects/Data/User/UserDataInterface/Sources/DTO/UserInfoDTO.swift
@@ -30,6 +30,6 @@ public struct UserInfoDTO: DTO {
   }
   
   public func toEntity() throws -> UserInfoEntity {
-    return .init(userId: userId, nickname: name)
+    return .init(userId: userId, nickname: nickname)
   }
 }

--- a/Projects/Data/User/UserDataInterface/Sources/DTO/WithdrawDTO.swift
+++ b/Projects/Data/User/UserDataInterface/Sources/DTO/WithdrawDTO.swift
@@ -1,0 +1,19 @@
+//
+//  WithdrawDTO.swift
+//  UserDataInterface
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import Networker
+
+public struct WithdrawDTO: DTO {
+  public typealias Entity = Void
+  let message: String
+  public init(message: String) {
+    self.message = message
+  }
+  public func toEntity() throws -> Void { }
+}

--- a/Projects/Data/User/UserDataInterface/Sources/EndPoint/UserEndPoint.swift
+++ b/Projects/Data/User/UserDataInterface/Sources/EndPoint/UserEndPoint.swift
@@ -30,4 +30,14 @@ public struct UserEndPoint: Sendable {
       path: "/users"
     )
   }
+  
+  public static func changeNickname(body: ChangeNicknameBody) -> Endpoint<UserInfoDTO> {
+    return Endpoint(
+      headers: .authorization(UserDefault.accessToken ?? ""),
+      method: .put,
+      baseURL: baseURL,
+      path: "/users/nickname",
+      parameters: .body(body)
+    )
+  }
 }

--- a/Projects/Data/User/UserDataInterface/Sources/EndPoint/UserEndPoint.swift
+++ b/Projects/Data/User/UserDataInterface/Sources/EndPoint/UserEndPoint.swift
@@ -1,0 +1,24 @@
+//
+//  UserEndPoint.swift
+//  UserDataInterface
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import Networker
+import UserDefault
+
+public struct UserEndPoint: Sendable {
+  static let baseURL = "https://api.pida.me/api/v1"
+  
+  public static func fetchUserInfo() -> Endpoint<UserInfoDTO> {
+    return Endpoint(
+      headers: .authorization(UserDefault.accessToken ?? ""),
+      method: .get,
+      baseURL: baseURL,
+      path: "/users/me"
+    )
+  }
+}

--- a/Projects/Data/User/UserDataInterface/Sources/EndPoint/UserEndPoint.swift
+++ b/Projects/Data/User/UserDataInterface/Sources/EndPoint/UserEndPoint.swift
@@ -21,4 +21,13 @@ public struct UserEndPoint: Sendable {
       path: "/users/me"
     )
   }
+  
+  public static func withDraw() -> Endpoint<WithdrawDTO> {
+    return Endpoint(
+      headers: .authorization(UserDefault.accessToken ?? ""),
+      method: .delete,
+      baseURL: baseURL,
+      path: "/users"
+    )
+  }
 }

--- a/Projects/Data/User/UserDataInterface/Sources/Parameters/ChangeNicknameBody.swift
+++ b/Projects/Data/User/UserDataInterface/Sources/Parameters/ChangeNicknameBody.swift
@@ -1,0 +1,16 @@
+//
+//  ChangeNicknameBody.swift
+//  UserDataInterface
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public struct ChangeNicknameBody: Encodable {
+  let nickname: String
+  public init(nickname: String) {
+    self.nickname = nickname
+  }
+}

--- a/Projects/Data/User/UserDataTesting/Sources/UserRepositoryTests.swift
+++ b/Projects/Data/User/UserDataTesting/Sources/UserRepositoryTests.swift
@@ -1,0 +1,30 @@
+//
+//  UserDataTests.swift
+//
+//  User
+//
+//  Created by JiYeon
+//
+
+import XCTest
+import Dependencies
+@testable import UserDataInterface
+@testable import UserDomainInterface
+@testable import Core
+
+final class UserRepositoryTests: XCTestCase {
+
+  func testFetchData() async throws {
+    let networker = MockNetworker()
+    let repository = UserRepositoryImpl(networker: networker)
+
+    let result = try await repository.requestMockData()
+    XCTAssertEqual(result, "Mocked API Data")
+  }
+}
+
+final class UserRepositoryImpl: UserRepository {
+  func requestMockData() async throws -> String {
+    return "Mocked API Data"
+  }
+}

--- a/Projects/Domain/Auth/AuthDomain/Sources/LogoutUseCaseImpl.swift
+++ b/Projects/Domain/Auth/AuthDomain/Sources/LogoutUseCaseImpl.swift
@@ -1,0 +1,23 @@
+//
+//  LogoutUseCaseImpl.swift
+//  AuthDomain
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import AuthDomainInterface
+import UserDefault
+
+public struct LogoutUseCaseImpl: LogoutUseCase {
+  private let repository: AuthRepository
+  
+  public init(repository: AuthRepository) {
+    self.repository = repository
+  }
+  
+  public func execute() async throws {
+    return try await repository.logout(token: UserDefault.accessToken ?? "")
+  }
+}

--- a/Projects/Domain/Auth/AuthDomain/Sources/SignUpUseCaseImpl.swift
+++ b/Projects/Domain/Auth/AuthDomain/Sources/SignUpUseCaseImpl.swift
@@ -17,7 +17,6 @@ public struct SignUpUseCaseImpl: SignUpUseCase {
   }
   
   public func execute(email: String, nickname: String) async throws -> Void {
-    let result = try await repository.signUp(email: email, nickname: nickname)
-    print(result.message)
+    let _ = try await repository.signUp(email: email, nickname: nickname)
   }
 }

--- a/Projects/Domain/Auth/AuthDomain/Sources/TokenDeleteUseCaseImpl.swift
+++ b/Projects/Domain/Auth/AuthDomain/Sources/TokenDeleteUseCaseImpl.swift
@@ -18,5 +18,6 @@ public struct TokenDeleteUseCaseImpl: TokenDeleteUseCase {
     UserDefault.isLoggedIn = false
     UserDefault.accessToken = nil
     KeyChainWrapper.delete(forKey: .refreshToken)
+    UserDefault.username = nil
   }
 }

--- a/Projects/Domain/Auth/AuthDomainInterface/Sources/AuthRepository.swift
+++ b/Projects/Domain/Auth/AuthDomainInterface/Sources/AuthRepository.swift
@@ -11,4 +11,5 @@ import Foundation
 public protocol AuthRepository {
   func requestAppleLogin(token: String) async throws -> SocialLoginEntity
   func signUp(email: String, nickname: String) async throws -> SignUpEntity
+  func logout(token: String) async throws
 }

--- a/Projects/Domain/Auth/AuthDomainInterface/Sources/DependencyKey/LogoutUseCaseKey.swift
+++ b/Projects/Domain/Auth/AuthDomainInterface/Sources/DependencyKey/LogoutUseCaseKey.swift
@@ -1,0 +1,33 @@
+//
+//  LogoutUseCaseKey.swift
+//  AuthDomainInterface
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import Dependencies
+
+public enum LogoutUseCaseKey: DependencyKey {
+  public static var liveValue: LogoutUseCase { logoutUseCaseProvider() }
+  public static var previewValue: LogoutUseCase { logoutUseCaseProvider() }
+  public static var testValue: LogoutUseCase { logoutUseCaseProvider() }
+}
+
+var logoutUseCaseProvider: () -> LogoutUseCase = {
+  fatalError("LogoutUseCase Dependency not configured")
+}
+
+public func logoutUseCaseRegister(
+  provider: @escaping () -> LogoutUseCase
+) {
+  logoutUseCaseProvider = provider
+}
+
+extension DependencyValues {
+  public var logoutUseCase: LogoutUseCase {
+    get { self[LogoutUseCaseKey.self] }
+    set { self[LogoutUseCaseKey.self] = newValue }
+  }
+}

--- a/Projects/Domain/Auth/AuthDomainInterface/Sources/UseCases/LogoutUseCase.swift
+++ b/Projects/Domain/Auth/AuthDomainInterface/Sources/UseCases/LogoutUseCase.swift
@@ -1,0 +1,13 @@
+//
+//  LogOutUseCase.swift
+//  AuthDomainInterface
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public protocol LogoutUseCase {
+  func execute() async throws 
+}

--- a/Projects/Domain/User/UserDomain/Project.swift
+++ b/Projects/Domain/User/UserDomain/Project.swift
@@ -1,0 +1,18 @@
+//
+//  UserDomainImplementProject.swift
+//
+//  User
+//
+//  Created by JiYeon
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.makeImplementProject(
+  name: "User",
+  layer: .domain,
+  implementDependency: [
+    .Domain.User.Interface
+  ]
+)

--- a/Projects/Domain/User/UserDomain/Sources/ChangeNicknameUseCase.swift
+++ b/Projects/Domain/User/UserDomain/Sources/ChangeNicknameUseCase.swift
@@ -1,0 +1,22 @@
+//
+//  ChangeNicknameUseCase.swift
+//  UserDomain
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import UserDomainInterface
+
+public struct ChangeNicknameUseCaseImpl: ChangeNicknameUseCase {
+  private let repository: UserRepository
+  
+  public init(repository: UserRepository) {
+    self.repository = repository
+  }
+  
+  public func execute(nickname: String) async throws -> UserInfoEntity {
+    return try await repository.changeNickname(nickname: nickname)
+  }
+}

--- a/Projects/Domain/User/UserDomain/Sources/FetchUserInfoUseCaseImpl.swift
+++ b/Projects/Domain/User/UserDomain/Sources/FetchUserInfoUseCaseImpl.swift
@@ -1,0 +1,22 @@
+//
+//  FetchUserInfoUseCaseImpl.swift
+//  UserDomain
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import UserDomainInterface
+
+public struct FetchUserInfoUseCaseImpl: FetchUserInfoUseCase {
+  private let repository: UserRepository
+  
+  public init(reporsitory: UserRepository) {
+    self.repository = reporsitory
+  }
+  
+  public func execute() async throws -> UserInfoEntity {
+    return try await repository.fetchUserInfo()
+  }
+}

--- a/Projects/Domain/User/UserDomain/Sources/WithdrawUseCaseImpl.swift
+++ b/Projects/Domain/User/UserDomain/Sources/WithdrawUseCaseImpl.swift
@@ -1,5 +1,5 @@
 //
-//  FetchUserInfoUseCaseImpl.swift
+//  WithdrawUseCaseImpl.swift
 //  UserDomain
 //
 //  Created by Jiyeon on 3/29/25.
@@ -9,14 +9,13 @@
 import Foundation
 import UserDomainInterface
 
-public struct FetchUserInfoUseCaseImpl: FetchUserInfoUseCase {
+public struct WithdrawUseCaseImpl: WithdrawUseCase {
   private let repository: UserRepository
   
   public init(repository: UserRepository) {
     self.repository = repository
   }
-  
-  public func execute() async throws -> UserInfoEntity {
-    return try await repository.fetchUserInfo()
+  public func execute() async throws {
+    return try await repository.withdraw()
   }
 }

--- a/Projects/Domain/User/UserDomainInterface/Project.swift
+++ b/Projects/Domain/User/UserDomainInterface/Project.swift
@@ -1,0 +1,19 @@
+//
+//  UserDomainInterfaceProject.swift
+//
+//  User
+//
+//  Created by JiYeon
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.makeInterfaceProject(
+  name: "User",
+  layer: .domain,
+  interfaceDependency: [
+    .InternalDependency.Core
+  ]
+)
+

--- a/Projects/Domain/User/UserDomainInterface/Sources/DependencyKey/ChangeNicknameUseCaseKey.swift
+++ b/Projects/Domain/User/UserDomainInterface/Sources/DependencyKey/ChangeNicknameUseCaseKey.swift
@@ -1,0 +1,33 @@
+//
+//  ChangeNicknameUseCaseKey.swift
+//  UserDomainInterface
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import Dependencies
+
+public enum ChangeNicknameUseCaseKey: DependencyKey {
+  public static var liveValue: ChangeNicknameUseCase { changeNicknameUseCaseProvider() }
+  public static var previewValue: ChangeNicknameUseCase { changeNicknameUseCaseProvider() }
+  public static var testValue: ChangeNicknameUseCase { changeNicknameUseCaseProvider() }
+}
+
+var changeNicknameUseCaseProvider: () -> ChangeNicknameUseCase = {
+  fatalError("FetchUserInfoUseCase Dependency not configured")
+}
+
+public func changeNicknameUseCaseRegister(
+  provider: @escaping () -> ChangeNicknameUseCase
+) {
+  changeNicknameUseCaseProvider = provider
+}
+
+extension DependencyValues {
+  public var changeNicknameUseCase: ChangeNicknameUseCase {
+    get { self[ChangeNicknameUseCaseKey.self] }
+    set { self[ChangeNicknameUseCaseKey.self] = newValue }
+  }
+}

--- a/Projects/Domain/User/UserDomainInterface/Sources/DependencyKey/FetchUserInfoUseCaseKey.swift
+++ b/Projects/Domain/User/UserDomainInterface/Sources/DependencyKey/FetchUserInfoUseCaseKey.swift
@@ -1,0 +1,33 @@
+//
+//  FetchUserInfoUseCaseKey.swift
+//  UserDomainInterface
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import Dependencies
+
+public enum FetchUserInfoUseCaseKey: DependencyKey {
+  public static var liveValue: FetchUserInfoUseCase { fetchUserInfoUseCaseProvider() }
+  public static var previewValue: FetchUserInfoUseCase { fetchUserInfoUseCaseProvider() }
+  public static var testValue: FetchUserInfoUseCase { fetchUserInfoUseCaseProvider() }
+}
+
+var fetchUserInfoUseCaseProvider: () -> FetchUserInfoUseCase = {
+  fatalError("FetchAllFlowerPinUseCase Dependency not configured")
+}
+
+public func fetchUserInfoUseCaseRegister(
+  provider: @escaping () -> FetchUserInfoUseCase
+) {
+  fetchUserInfoUseCaseProvider = provider
+}
+
+extension DependencyValues {
+  public var fetchUserInfoUseCase: FetchUserInfoUseCase {
+    get { self[FetchUserInfoUseCaseKey.self] }
+    set { self[FetchUserInfoUseCaseKey.self] = newValue }
+  }
+}

--- a/Projects/Domain/User/UserDomainInterface/Sources/DependencyKey/FetchUserInfoUseCaseKey.swift
+++ b/Projects/Domain/User/UserDomainInterface/Sources/DependencyKey/FetchUserInfoUseCaseKey.swift
@@ -16,7 +16,7 @@ public enum FetchUserInfoUseCaseKey: DependencyKey {
 }
 
 var fetchUserInfoUseCaseProvider: () -> FetchUserInfoUseCase = {
-  fatalError("FetchAllFlowerPinUseCase Dependency not configured")
+  fatalError("FetchUserInfoUseCase Dependency not configured")
 }
 
 public func fetchUserInfoUseCaseRegister(

--- a/Projects/Domain/User/UserDomainInterface/Sources/DependencyKey/WithdrawUseCaseKey.swift
+++ b/Projects/Domain/User/UserDomainInterface/Sources/DependencyKey/WithdrawUseCaseKey.swift
@@ -1,0 +1,33 @@
+//
+//  WithdrawUseCaseKey.swift
+//  UserDomainInterface
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import Dependencies
+
+public enum WithdrawUseCaseKey: DependencyKey {
+  public static var liveValue: WithdrawUseCase { withdrawUseCaseProvider() }
+  public static var previewValue: WithdrawUseCase { withdrawUseCaseProvider() }
+  public static var testValue: WithdrawUseCase { withdrawUseCaseProvider() }
+}
+
+var withdrawUseCaseProvider: () -> WithdrawUseCase = {
+  fatalError("withdrawUseCaseProvider Dependency not configured")
+}
+
+public func withdrawUseCaseRegister(
+  provider: @escaping () -> WithdrawUseCase
+) {
+  withdrawUseCaseProvider = provider
+}
+
+extension DependencyValues {
+  public var withdrawUseCase: WithdrawUseCase {
+    get { self[WithdrawUseCaseKey.self] }
+    set { self[WithdrawUseCaseKey.self] = newValue }
+  }
+}

--- a/Projects/Domain/User/UserDomainInterface/Sources/Entity/UserInfoEntity.swift
+++ b/Projects/Domain/User/UserDomainInterface/Sources/Entity/UserInfoEntity.swift
@@ -1,0 +1,18 @@
+//
+//  UserInfoEntity.swift
+//  UserDomainInterface
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public struct UserInfoEntity: Sendable, Equatable {
+  public var userId: Int
+  public var nickname: String
+  public init(userId: Int, nickname: String) {
+    self.userId = userId
+    self.nickname = nickname
+  }
+}

--- a/Projects/Domain/User/UserDomainInterface/Sources/UseCases/ChangeNicknameUseCase.swift
+++ b/Projects/Domain/User/UserDomainInterface/Sources/UseCases/ChangeNicknameUseCase.swift
@@ -1,0 +1,13 @@
+//
+//  ChangeNicknameUseCase.swift
+//  UserDomainInterface
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public protocol ChangeNicknameUseCase {
+  func execute(nickname: String) async throws -> UserInfoEntity
+}

--- a/Projects/Domain/User/UserDomainInterface/Sources/UseCases/FetchUserInfoUseCase.swift
+++ b/Projects/Domain/User/UserDomainInterface/Sources/UseCases/FetchUserInfoUseCase.swift
@@ -1,0 +1,13 @@
+//
+//  FetchUserInfoUseCase.swift
+//  UserDomainInterface
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public protocol FetchUserInfoUseCase {
+  func execute() async throws -> UserInfoEntity
+}

--- a/Projects/Domain/User/UserDomainInterface/Sources/UseCases/WithdrawUseCase.swift
+++ b/Projects/Domain/User/UserDomainInterface/Sources/UseCases/WithdrawUseCase.swift
@@ -1,0 +1,13 @@
+//
+//  WithdrawUseCase.swift
+//  UserDomainInterface
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public protocol WithdrawUseCase {
+  func execute() async throws
+}

--- a/Projects/Domain/User/UserDomainInterface/Sources/UserRepository.swift
+++ b/Projects/Domain/User/UserDomainInterface/Sources/UserRepository.swift
@@ -1,0 +1,13 @@
+//
+//  UserRepository.swift
+//
+//  User
+//
+//  Created by JiYeon
+//
+
+import Foundation
+
+public protocol UserRepository {
+  func fetchUserInfo() async throws -> UserInfoEntity
+}

--- a/Projects/Domain/User/UserDomainInterface/Sources/UserRepository.swift
+++ b/Projects/Domain/User/UserDomainInterface/Sources/UserRepository.swift
@@ -10,4 +10,5 @@ import Foundation
 
 public protocol UserRepository {
   func fetchUserInfo() async throws -> UserInfoEntity
+  func withdraw() async throws
 }

--- a/Projects/Domain/User/UserDomainInterface/Sources/UserRepository.swift
+++ b/Projects/Domain/User/UserDomainInterface/Sources/UserRepository.swift
@@ -11,4 +11,5 @@ import Foundation
 public protocol UserRepository {
   func fetchUserInfo() async throws -> UserInfoEntity
   func withdraw() async throws
+  func changeNickname(nickname: String) async throws -> UserInfoEntity
 }

--- a/Projects/Domain/User/UserDomainTesting/Sources/UserUseCaseTests.swift
+++ b/Projects/Domain/User/UserDomainTesting/Sources/UserUseCaseTests.swift
@@ -1,0 +1,28 @@
+//
+//  UserUseCaseTests.swift
+//
+//  User
+//
+//  Created by JiYeon
+//
+
+import XCTest
+import Dependencies
+@testable import UserDomain
+
+final class UserUseCaseTests: XCTestCase {
+    
+  func testExecute() async throws {
+      let repository = MockUserRepository()
+      let useCase = UserUseCaseImpl(repository: repository)
+
+      let result = try await useCase.execute()
+      XCTAssertEqual(result, "Mocked Data")
+  }
+}
+
+final class MockUserRepository: UserRepository {
+  func fetchData() async throws -> String {
+      return "Mocked Data"
+  }
+}

--- a/Projects/Features/Auth/AuthFeature/Sources/AuthReducer.swift
+++ b/Projects/Features/Auth/AuthFeature/Sources/AuthReducer.swift
@@ -41,6 +41,7 @@ extension AuthReducer {
           do {
             let result = try await appleLoginUseCase.execute(token: info.idToken)
             // 토큰 저장
+            print(result)
             await tokenSaveUseCase.execute(tokenInfo: result)
             if result.isTempToken { // 최초 회원가입
               await send(.presentToSignUp)

--- a/Projects/Features/Auth/AuthFeature/Sources/AuthReducer.swift
+++ b/Projects/Features/Auth/AuthFeature/Sources/AuthReducer.swift
@@ -7,11 +7,14 @@
 //
 
 import AuthFeatureInterface
+import UserDomainInterface
 import ComposableArchitecture
 import Utility
+import UserDefault
 
 extension AuthReducer {
   public init() {
+    @Dependency(\.fetchUserInfoUseCase) var userInfoUseCase
     @Dependency(\.appleLoginUseCase) var appleLoginUseCase
     @Dependency(\.tokenSaveUseCase) var tokenSaveUseCase
     @Dependency(\.mainQueue) var mainQueue
@@ -42,9 +45,23 @@ extension AuthReducer {
             if result.isTempToken { // 최초 회원가입
               await send(.presentToSignUp)
             } else {
-              await send(.dismiss)
+              await send(.fetchUserInfo)
             }
           } catch let error as NetworkError {
+            print(error.localizedDescription)
+          } catch {
+            print(error.localizedDescription)
+          }
+        }
+      case .fetchUserInfo:
+        return .run { send in
+          do {
+            let result = try await userInfoUseCase.execute()
+            UserDefault.username = result.nickname
+            await send(.dismiss)
+          } catch let error as NetworkError {
+            print(error.localizedDescription)
+          } catch let error as FoundationError {
             print(error.localizedDescription)
           } catch {
             print(error.localizedDescription)

--- a/Projects/Features/Auth/AuthFeature/Sources/AuthReducer.swift
+++ b/Projects/Features/Auth/AuthFeature/Sources/AuthReducer.swift
@@ -41,7 +41,6 @@ extension AuthReducer {
           do {
             let result = try await appleLoginUseCase.execute(token: info.idToken)
             // 토큰 저장
-            print(result)
             await tokenSaveUseCase.execute(tokenInfo: result)
             if result.isTempToken { // 최초 회원가입
               await send(.presentToSignUp)
@@ -49,7 +48,7 @@ extension AuthReducer {
               await send(.fetchUserInfo)
             }
           } catch let error as NetworkError {
-            print(error.localizedDescription)
+            print(error.errorDescription)
           } catch {
             print(error.localizedDescription)
           }
@@ -61,9 +60,9 @@ extension AuthReducer {
             UserDefault.username = result.nickname
             await send(.dismiss)
           } catch let error as NetworkError {
-            print(error.localizedDescription)
+            print(error.errorDescription)
           } catch let error as FoundationError {
-            print(error.localizedDescription)
+            print(error.errorDescription)
           } catch {
             print(error.localizedDescription)
           }

--- a/Projects/Features/Auth/AuthFeature/Sources/SignUpReducer.swift
+++ b/Projects/Features/Auth/AuthFeature/Sources/SignUpReducer.swift
@@ -8,14 +8,15 @@
 
 import ComposableArchitecture
 import AuthFeatureInterface
+import UserDomainInterface
 import KeyChain
 import UserDefault
 
 extension SignUpReducer {
   public init() {
+    @Dependency(\.fetchUserInfoUseCase) var userInfoUseCase
     @Dependency(\.signUpUseCase) var signUpUseCase
     @Dependency(\.mainQueue) var mainQueue
-    
     let reducer = Reduce<State, Action> { state, action in
       switch action {
         
@@ -24,13 +25,20 @@ extension SignUpReducer {
       case .onAppear:
         return .run { send in
           await MainActor.run {
+            send(.initState)
             send(.showKeyboard(true))
           }
         }
       case let .showKeyboard(isShow):
         state.focusKeyboard = isShow
         return .none
+      case .initState:
+        state.nickname = ""
+        state.isValidInput = true
+        state.inputValid = .none
+        state.isLoading = false
         
+        return .none
       case .confirmTapped:
         return .send(.requestSignUp(nickname: state.nickname))
           .throttle(id: ID.throttle, for: 0.3, scheduler: mainQueue, latest: false)
@@ -53,7 +61,7 @@ extension SignUpReducer {
             if let email: String = KeyChainWrapper.read(forKey: .email) {
               try await signUpUseCase.execute(email: email, nickname: nickname)
               UserDefault.isLoggedIn = true
-              await send(.dismiss)
+              await send(.fetchUserInfo)
             }
           } catch {
             print(error.localizedDescription)
@@ -62,6 +70,17 @@ extension SignUpReducer {
       case .failSignUp:
         state.isLoading = false
         return .none
+        
+      case .fetchUserInfo:
+        return .run { send in
+          do {
+            let result = try await userInfoUseCase.execute()
+            UserDefault.username = result.nickname
+            await send(.dismiss)
+          } catch {
+            print(error.localizedDescription)
+          }
+        }
         
       case .dismiss:
         return .run { send in

--- a/Projects/Features/Auth/AuthFeature/Sources/SignUpReducer.swift
+++ b/Projects/Features/Auth/AuthFeature/Sources/SignUpReducer.swift
@@ -11,6 +11,7 @@ import AuthFeatureInterface
 import UserDomainInterface
 import KeyChain
 import UserDefault
+import Utility
 
 extension SignUpReducer {
   public init() {

--- a/Projects/Features/Auth/AuthFeature/Sources/SignUpReducer.swift
+++ b/Projects/Features/Auth/AuthFeature/Sources/SignUpReducer.swift
@@ -33,6 +33,7 @@ extension SignUpReducer {
       case let .showKeyboard(isShow):
         state.focusKeyboard = isShow
         return .none
+        
       case .initState:
         state.nickname = ""
         state.isValidInput = true

--- a/Projects/Features/Auth/AuthFeatureInterface/Sources/Login/AuthReducer.swift
+++ b/Projects/Features/Auth/AuthFeatureInterface/Sources/Login/AuthReducer.swift
@@ -28,6 +28,7 @@ public struct AuthReducer {
     case appleLoginRequest
     case appleLoginResponse(AppleLoginResult)
     case appleLoginFailure
+    case fetchUserInfo
     
     case delegate(Delegate)
     case dismiss

--- a/Projects/Features/Auth/AuthFeatureInterface/Sources/Login/AuthView.swift
+++ b/Projects/Features/Auth/AuthFeatureInterface/Sources/Login/AuthView.swift
@@ -67,7 +67,7 @@ public struct AuthView: View {
     .action {
       store.send(.appleLoginButtonTapped)
     }
-    .backgroundColor(ColorSet.Background.Inverse)
+    .backgroundColor(ColorSet.Gray._1000)
     .foregroundStyle(ColorSet.Background.Primary)
     .frame(height: .Number48)
   }

--- a/Projects/Features/Auth/AuthFeatureInterface/Sources/SignUp/SignUpReducer.swift
+++ b/Projects/Features/Auth/AuthFeatureInterface/Sources/SignUp/SignUpReducer.swift
@@ -30,12 +30,13 @@ public struct SignUpReducer {
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
     case onAppear
+    case initState
     case showKeyboard(Bool)
     case confirmTapped
     case checkValidNickName(String)
     case requestSignUp(nickname: String)
     case failSignUp
-    
+    case fetchUserInfo
     
     case dismiss
     case delegate(Delegate)

--- a/Projects/Features/Auth/Project.swift
+++ b/Projects/Features/Auth/Project.swift
@@ -12,7 +12,8 @@ import ProjectDescriptionHelpers
 let project = Project.makeFeature(
   name: "Auth",
   featureInterfaceDependencies: [
-    .Domain.Auth.Interface
+    .Domain.Auth.Interface,
+    .Domain.User.Interface
     // 필요 시, Domain Interface Dependency 추가
   ]
 )

--- a/Projects/Features/Setting/Project.swift
+++ b/Projects/Features/Setting/Project.swift
@@ -12,7 +12,8 @@ import ProjectDescriptionHelpers
 let project = Project.makeFeature(
   name: "Setting",
   featureInterfaceDependencies: [
-    .Domain.Setting.Interface
+    .Domain.Setting.Interface,
+    .Domain.User.Interface
     // 필요 시, Domain Interface Dependency 추가
   ]
 )

--- a/Projects/Features/Setting/SettingFeature/Sources/ProfileUpdateReducer.swift
+++ b/Projects/Features/Setting/SettingFeature/Sources/ProfileUpdateReducer.swift
@@ -9,31 +9,49 @@
 import ComposableArchitecture
 import SettingFeatureInterface
 import Utility
+import UserDefault
 
 extension ProfileUpdateReducer {
   public init() {
     let reducer = Reduce<State, Action> { state, action in
       switch action {
+      case .binding(\.changeName):
+        return .send(.checkValidNickName(state.changeName))
+        
       case .onAppear:
-        
-        return .none
-        
-      case .saveTapped:
-        return .send(.checkValidNickName(state.nickname))
-      case let .checkValidNickName(nickname):
-        if nickname.count < 2 {
-          state.inputValid = .tooShort
-          state.isValidInput = false
-        } else if nickname.count > 12 {
-          state.inputValid = .tooLong
-          state.isValidInput = false
-        } else {
-          state.inputValid = .valid
-          state.isValidInput = true
-          // TODO: - API 연결
-          return .send(.pop)
+        if let nickname = UserDefault.username {
+          state.nickname = nickname
+          state.changeName = nickname
         }
         return .none
+        
+      case let .showKeyboard(isShow):
+        state.focusKeyboard = isShow
+        return .none
+
+      case .saveTapped:
+        return .run { send in
+          await send(.showKeyboard(false))
+          await send(.pop)
+        }
+        
+      case let .checkValidNickName(nickname):
+        // 이전 이름과 같을 경우
+        if nickname == state.nickname {
+          state.inputValid = .none
+          state.isValidInput = true
+          return .none
+        }
+        if nickname.count < 2 {
+          state.inputValid = .tooShort
+        } else if nickname.count > 12 {
+          state.inputValid = .tooLong
+        } else {
+          state.inputValid = .valid
+        }
+        state.isValidInput = state.inputValid.isValid
+        return .none
+        
       case .pop:
         state.nickname = ""
         state.inputValid = .none

--- a/Projects/Features/Setting/SettingFeature/Sources/ProfileUpdateReducer.swift
+++ b/Projects/Features/Setting/SettingFeature/Sources/ProfileUpdateReducer.swift
@@ -1,0 +1,49 @@
+//
+//  ProfileUpdateReducer.swift
+//  SettingDemo
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import ComposableArchitecture
+import SettingFeatureInterface
+import Utility
+
+extension ProfileUpdateReducer {
+  public init() {
+    let reducer = Reduce<State, Action> { state, action in
+      switch action {
+      case .onAppear:
+        
+        return .none
+        
+      case .saveTapped:
+        return .send(.checkValidNickName(state.nickname))
+      case let .checkValidNickName(nickname):
+        if nickname.count < 2 {
+          state.inputValid = .tooShort
+          state.isValidInput = false
+        } else if nickname.count > 12 {
+          state.inputValid = .tooLong
+          state.isValidInput = false
+        } else {
+          state.inputValid = .valid
+          state.isValidInput = true
+          // TODO: - API 연결
+          return .send(.pop)
+        }
+        return .none
+      case .pop:
+        state.nickname = ""
+        state.inputValid = .none
+        return .send(.delegate(.pop))
+        
+      case .binding, .delegate:
+        return .none
+      }
+    }
+    
+    self.init(reducer: reducer)
+  }
+}

--- a/Projects/Features/Setting/SettingFeature/Sources/ProfileUpdateReducer.swift
+++ b/Projects/Features/Setting/SettingFeature/Sources/ProfileUpdateReducer.swift
@@ -13,6 +13,9 @@ import UserDefault
 
 extension ProfileUpdateReducer {
   public init() {
+    @Dependency(\.changeNicknameUseCase) var changeNicknameUseCase
+    @Dependency(\.mainQueue) var mainQueue
+    
     let reducer = Reduce<State, Action> { state, action in
       switch action {
       case .binding(\.changeName):
@@ -30,10 +33,8 @@ extension ProfileUpdateReducer {
         return .none
 
       case .saveTapped:
-        return .run { send in
-          await send(.showKeyboard(false))
-          await send(.pop)
-        }
+        return .send(.changeNickName(state.changeName))
+          .throttle(id: ID.throttle, for: 0.3, scheduler: mainQueue, latest: false)
         
       case let .checkValidNickName(nickname):
         // 이전 이름과 같을 경우
@@ -52,10 +53,26 @@ extension ProfileUpdateReducer {
         state.isValidInput = state.inputValid.isValid
         return .none
         
+      case let .changeNickName(nickname):
+        return .run { send in
+          do {
+            let result = try await changeNicknameUseCase.execute(nickname: nickname)
+            UserDefault.username = result.nickname
+            await send(.pop)
+          } catch {
+            print(error.localizedDescription)
+          }
+        }
       case .pop:
         state.nickname = ""
         state.inputValid = .none
-        return .send(.delegate(.pop))
+        return .run { send in
+          await MainActor.run {
+            send(.showKeyboard(false))
+            send(.delegate(.pop))
+          }
+        }
+        
         
       case .binding, .delegate:
         return .none

--- a/Projects/Features/Setting/SettingFeature/Sources/ProfileUpdateReducer.swift
+++ b/Projects/Features/Setting/SettingFeature/Sources/ProfileUpdateReducer.swift
@@ -31,6 +31,13 @@ extension ProfileUpdateReducer {
       case let .showKeyboard(isShow):
         state.focusKeyboard = isShow
         return .none
+      case let .showToastView(message):
+        state.toastMessage = message
+        return .none
+        
+      case let .isLoading(isLoading):
+        state.isLoading = isLoading
+        return .none
 
       case .saveTapped:
         return .send(.changeNickName(state.changeName))
@@ -55,12 +62,14 @@ extension ProfileUpdateReducer {
         
       case let .changeNickName(nickname):
         return .run { send in
+          await send(.isLoading(true))
           do {
             let result = try await changeNicknameUseCase.execute(nickname: nickname)
             UserDefault.username = result.nickname
             await send(.pop)
           } catch {
-            print(error.localizedDescription)
+            await send(.isLoading(false))
+            await send(.showToastView(message: "닉네임 변경에 실패했어요."))
           }
         }
       case .pop:
@@ -68,6 +77,7 @@ extension ProfileUpdateReducer {
         state.inputValid = .none
         return .run { send in
           await MainActor.run {
+            send(.isLoading(false))
             send(.showKeyboard(false))
             send(.delegate(.pop))
           }

--- a/Projects/Features/Setting/SettingFeature/Sources/SettingReducer.swift
+++ b/Projects/Features/Setting/SettingFeature/Sources/SettingReducer.swift
@@ -29,8 +29,9 @@ extension SettingReducer {
         }
         return .none
       case .checkUserInfo:
-        // TODO: - 회원 조회 로직
-        state.username = "TEMP"
+        if let username = UserDefault.username {
+          state.username = username
+        }
         return .none
       case .profileTapped:
         if !state.isLoggedIn {

--- a/Projects/Features/Setting/SettingFeature/Sources/SettingReducer.swift
+++ b/Projects/Features/Setting/SettingFeature/Sources/SettingReducer.swift
@@ -19,6 +19,8 @@ extension SettingReducer {
     @Dependency(\.openURL) var openURL
     @Dependency(\.tokenDeleteUseCase) var tokenDeleteUseCase
     @Dependency(\.withdrawUseCase) var withdrawUseCase
+    @Dependency(\.logoutUseCase) var logoutUseCase
+    
     let reducer = Reduce<State, Action> { state, action in
       switch action {
       case .onAppear:
@@ -30,6 +32,7 @@ extension SettingReducer {
           return .send(.checkUserInfo)
         }
         return .none
+        
       case .checkUserInfo:
         if let username = UserDefault.username {
           state.username = username
@@ -46,6 +49,12 @@ extension SettingReducer {
           if let url = ExternalURL.feedBack {
             await openURL(url)
           }
+        }
+        
+      case .deleteToken:
+        return .run { send in
+          await tokenDeleteUseCase.execute()
+          await send(.checkLoggedIn)
         }
         
         // MARK: - SettingList Events
@@ -71,13 +80,22 @@ extension SettingReducer {
         return .run { send in
           do {
             try await withdrawUseCase.execute()
-            await tokenDeleteUseCase.execute()
+            await send(.deleteToken)
             await send(.clearAlertState)
-            await send(.checkLoggedIn)
-          } 
+          } catch {
+            await send(.deleteToken)
+          }
         }
       case .alertAcceptTapped(.logout):
-        return .none
+        return .run { send in
+          do {
+            try await logoutUseCase.execute()
+            await send(.deleteToken)
+            await send(.clearAlertState)
+          } catch {
+            await send(.deleteToken)
+          }
+        }
         
       case .clearAlertState:
         state.isAlertShow = false

--- a/Projects/Features/Setting/SettingFeature/Sources/SettingReducer.swift
+++ b/Projects/Features/Setting/SettingFeature/Sources/SettingReducer.swift
@@ -7,16 +7,18 @@
 //
 
 import SettingFeatureInterface
+import AuthDomainInterface
+import UserDomainInterface
+
 import ComposableArchitecture
 import Utility
 import UserDefault
-import AuthDomainInterface
 
 extension SettingReducer {
   public init() {
     @Dependency(\.openURL) var openURL
     @Dependency(\.tokenDeleteUseCase) var tokenDeleteUseCase
-    
+    @Dependency(\.withdrawUseCase) var withdrawUseCase
     let reducer = Reduce<State, Action> { state, action in
       switch action {
       case .onAppear:
@@ -65,12 +67,17 @@ extension SettingReducer {
         
       case .alertCancelTapped:
         return .send(.clearAlertState)
-      case .alertAcceptTapped:
+      case .alertAcceptTapped(.withdraw):
         return .run { send in
-          await tokenDeleteUseCase.execute()
-          await send(.clearAlertState)
-          await send(.checkLoggedIn)
+          do {
+            try await withdrawUseCase.execute()
+            await tokenDeleteUseCase.execute()
+            await send(.clearAlertState)
+            await send(.checkLoggedIn)
+          } 
         }
+      case .alertAcceptTapped(.logout):
+        return .none
         
       case .clearAlertState:
         state.isAlertShow = false
@@ -84,7 +91,7 @@ extension SettingReducer {
         
         // MARK: - None
         
-      case .delegate, .settingListTapped, .binding:
+      case .delegate, .settingListTapped, .binding, .alertAcceptTapped:
         return .none
       }
     }

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingReducer.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingReducer.swift
@@ -30,9 +30,10 @@ public struct SettingReducer {
     case onAppear
     case checkLoggedIn
     case checkUserInfo
-    case profileTapped
-    case feedBackTapped
+    case deleteToken
     
+    case feedBackTapped
+    case profileTapped
     case settingListTapped(SettingType)
     case alertCancelTapped
     case alertAcceptTapped(AlertType)

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingReducer.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingReducer.swift
@@ -35,7 +35,7 @@ public struct SettingReducer {
     
     case settingListTapped(SettingType)
     case alertCancelTapped
-    case alertAcceptTapped
+    case alertAcceptTapped(AlertType)
     case clearAlertState
     
     case delegate(Delegate)

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingView.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingView.swift
@@ -131,7 +131,7 @@ extension SettingView {
       cancelTitle: type.cancel,
       acceptTitle: type.accept,
       closeAction: { store.send(.alertCancelTapped) },
-      acceptAction: { store.send(.alertAcceptTapped) }
+      acceptAction: { store.send(.alertAcceptTapped(type)) }
     )
     .isErrorType(true)
   }

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingView.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingView.swift
@@ -76,16 +76,16 @@ extension SettingView {
   private var profileView: some View {
     HStack(alignment: .center, spacing: .Number16) {
       Image(asset: ImageSet.avatarLarge.swiftUIImage)
-      
-      if store.isLoggedIn {
-        Text("환영해요! \(store.username)님")
-      } else {
-        HStack(spacing: .Number0) {
+      HStack(spacing: .Number0) {
+        if store.isLoggedIn {
+          Text("환영해요! \(store.username)님")
+        } else {
           Text("로그인 하기")
-          Icon(image: .chevronRight)
-            .size(.extraLarge)
         }
+        Icon(image: .chevronRight)
+          .size(.extraLarge)
       }
+      
       Spacer()
     }
     .fontStyle(FontSet.Body.body2)

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateReducer.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateReducer.swift
@@ -21,7 +21,8 @@ public struct ProfileUpdateReducer {
   @ObservableState
   public struct State: Equatable {
     public var nickname: String = ""
-    public var isFocusKeyboard: Bool = false
+    public var changeName: String = ""
+    public var focusKeyboard: Bool = false
     public var inputValid: NickNameInputValid = .none
     public var isValidInput: Bool = false
     public init(){}
@@ -32,6 +33,7 @@ public struct ProfileUpdateReducer {
     case onAppear
     case saveTapped
     case checkValidNickName(String)
+    case showKeyboard(Bool)
     
     case delegate(Delegate)
     case pop

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateReducer.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateReducer.swift
@@ -23,15 +23,20 @@ public struct ProfileUpdateReducer {
     public var nickname: String = ""
     public var changeName: String = ""
     public var focusKeyboard: Bool = false
+    public var isLoading: Bool = false
     public var inputValid: NickNameInputValid = .none
     public var isValidInput: Bool = false
+    public var toastMessage: String? = nil
     public init(){}
   }
   
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
     case onAppear
+    case showToastView(message: String?)
+    
     case saveTapped
+    case isLoading(Bool)
     case checkValidNickName(String)
     case showKeyboard(Bool)
     case changeNickName(String)

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateReducer.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateReducer.swift
@@ -34,6 +34,7 @@ public struct ProfileUpdateReducer {
     case saveTapped
     case checkValidNickName(String)
     case showKeyboard(Bool)
+    case changeNickName(String)
     
     case delegate(Delegate)
     case pop
@@ -41,6 +42,10 @@ public struct ProfileUpdateReducer {
   
   public enum Delegate {
     case pop
+  }
+  
+  public enum ID: Hashable {
+    case throttle
   }
   
   public var body: some ReducerOf<Self> {

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateReducer.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateReducer.swift
@@ -1,17 +1,17 @@
 //
-//  SignUpReducer.swift
-//  AuthFeatureInterface
+//  ProfileUpdateReducer.swift
+//  SettingDemo
 //
-//  Created by Jiyeon on 3/27/25.
+//  Created by Jiyeon on 3/29/25.
 //  Copyright © 2025 com.yongin.pida. All rights reserved.
 //
 
+import Foundation
 import ComposableArchitecture
-import AuthDomainInterface
 import Utility
 
 @Reducer
-public struct SignUpReducer {
+public struct ProfileUpdateReducer {
   private let reducer: Reduce<State, Action>
   
   public init(reducer: Reduce<State, Action>) {
@@ -21,34 +21,24 @@ public struct SignUpReducer {
   @ObservableState
   public struct State: Equatable {
     public var nickname: String = ""
-    public var focusKeyboard: Bool = false
-    public var isValidInput: Bool = true
+    public var isFocusKeyboard: Bool = false
     public var inputValid: NickNameInputValid = .none
-    public var isLoading: Bool = false
-    public init() {}
+    public var isValidInput: Bool = false
+    public init(){}
   }
   
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
     case onAppear
-    case initState
-    case showKeyboard(Bool)
-    case confirmTapped
+    case saveTapped
     case checkValidNickName(String)
-    case requestSignUp(nickname: String)
-    case failSignUp
-    case fetchUserInfo
     
-    case dismiss
     case delegate(Delegate)
+    case pop
   }
   
-  public enum Delegate: Equatable {
-    case dismiss
-  }
-  
-  public enum ID: Hashable {
-    case throttle
+  public enum Delegate {
+    case pop
   }
   
   public var body: some ReducerOf<Self> {
@@ -57,4 +47,3 @@ public struct SignUpReducer {
   }
   
 }
-

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateView.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateView.swift
@@ -24,6 +24,7 @@ public struct ProfileUpdateView: View {
         navigationBar
         nicknameTextField
         Spacer()
+        ToastView(message: $store.toastMessage)
         saveButton
       }
     }
@@ -68,6 +69,7 @@ public struct ProfileUpdateView: View {
         store.send(.saveTapped)
       }
       .isActive(store.inputValid.isValid)
+      .disabled(store.isLoading)
       .padding(.Number16)
   }
   

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateView.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateView.swift
@@ -1,0 +1,71 @@
+//
+//  ProfileUpdateView.swift
+//  SettingDemo
+//
+//  Created by Jiyeon on 3/29/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import SwiftUI
+import DesignKit
+import ComposableArchitecture
+
+public struct ProfileUpdateView: View {
+  @Bindable var store: StoreOf<ProfileUpdateReducer>
+  
+  public init(store: StoreOf<ProfileUpdateReducer>) {
+    self.store = store
+  }
+  public var body: some View {
+    ZStack {
+      ColorSet.Background.Primary
+        .ignoresSafeArea()
+      VStack {
+        navigationBar
+        PIDATextField(
+          text: $store.nickname,
+          placeholder: "닉네임",
+          isFocused: $store.isFocusKeyboard
+        )
+        .message(store.inputValid.text)
+        .borderStyle(store.isValidInput ? .accent : .error)
+        .padding(.horizontal, .Number16)
+        Spacer()
+        
+        saveButton
+      }
+      
+    }
+    .navigationBarBackButtonHidden(true)
+    .onAppear {
+      store.send(.onAppear)
+    }
+  }
+  
+  @ViewBuilder
+  private var navigationBar: some View {
+    NavigationGestureSupportView()
+      .frame(width: .Number0, height: .Number0)
+    NavigationBar(
+      backContent: {
+        TouchArea(image: .back)
+          .size(.superLarge)
+          .action {
+            store.send(.pop)
+          }
+      },
+      title: "닉네임 변경"
+    )
+  }
+  
+  
+  @ViewBuilder
+  private var saveButton: some View {
+    PIDButton(title: "저장하기", size: .large)
+      .action {
+        store.send(.saveTapped)
+      }
+      .padding(.Number16)
+  }
+  
+}

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateView.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateView.swift
@@ -22,19 +22,10 @@ public struct ProfileUpdateView: View {
         .ignoresSafeArea()
       VStack {
         navigationBar
-        PIDATextField(
-          text: $store.nickname,
-          placeholder: "닉네임",
-          isFocused: $store.isFocusKeyboard
-        )
-        .message(store.inputValid.text)
-        .borderStyle(store.isValidInput ? .accent : .error)
-        .padding(.horizontal, .Number16)
+        nicknameTextField
         Spacer()
-        
         saveButton
       }
-      
     }
     .navigationBarBackButtonHidden(true)
     .onAppear {
@@ -58,6 +49,17 @@ public struct ProfileUpdateView: View {
     )
   }
   
+  @ViewBuilder
+  private var nicknameTextField: some View {
+    PIDATextField(
+      text: $store.changeName,
+      placeholder: "닉네임",
+      isFocused: $store.focusKeyboard
+    )
+    .message(store.inputValid.text)
+    .borderStyle(!store.isValidInput ? .error: .accent)
+    .padding(.horizontal, .Number16)
+  }
   
   @ViewBuilder
   private var saveButton: some View {
@@ -65,6 +67,7 @@ public struct ProfileUpdateView: View {
       .action {
         store.send(.saveTapped)
       }
+      .isActive(store.inputValid.isValid)
       .padding(.Number16)
   }
   

--- a/Projects/PIDA/Project.swift
+++ b/Projects/PIDA/Project.swift
@@ -38,7 +38,10 @@ let project = Project.makePIDA(
 
     .Features.Auth.Implement,
     .Domain.Auth.Implement,
-    .Data.Auth.Implement
+    .Data.Auth.Implement,
+    
+    .Data.User.Implement,
+    .Domain.User.Implement,
 
   ]
 )

--- a/Projects/PIDA/Sources/DependencyRegister.swift
+++ b/Projects/PIDA/Sources/DependencyRegister.swift
@@ -68,6 +68,8 @@ enum DependencyRegistry {
     withdrawUseCaseRegister(
       provider: { WithdrawUseCaseImpl(repository: userRepository)}
     )
-    
+    changeNicknameUseCaseRegister(
+      provider: { ChangeNicknameUseCaseImpl(repository: userRepository) }
+    )
   }
 }

--- a/Projects/PIDA/Sources/DependencyRegister.swift
+++ b/Projects/PIDA/Sources/DependencyRegister.swift
@@ -60,9 +60,11 @@ enum DependencyRegistry {
     // MARK: - User
     
     fetchUserInfoUseCaseRegister(
-      provider: { FetchUserInfoUseCaseImpl(reporsitory: userRepository) }
+      provider: { FetchUserInfoUseCaseImpl(repository: userRepository) }
     )
-    
+    withdrawUseCaseRegister(
+      provider: { WithdrawUseCaseImpl(repository: userRepository)}
+    )
     
   }
 }

--- a/Projects/PIDA/Sources/DependencyRegister.swift
+++ b/Projects/PIDA/Sources/DependencyRegister.swift
@@ -56,6 +56,9 @@ enum DependencyRegistry {
     tokenDeleteUseCaseRegister(
       provider: { TokenDeleteUseCaseImpl() }
     )
+    logoutUseCaseRegister(
+      provider: { LogoutUseCaseImpl(repository: authRepository) }
+    )
     
     // MARK: - User
     

--- a/Projects/PIDA/Sources/DependencyRegister.swift
+++ b/Projects/PIDA/Sources/DependencyRegister.swift
@@ -20,11 +20,17 @@ import AuthDomain
 import AuthDataInterface
 import AuthData
 
+import UserDomainInterface
+import UserDomain
+import UserDataInterface
+import UserData
+
 enum DependencyRegistry {
   static func registerDependencies() {
     let networker = Networker()
     let flowerSpotRepository = FlowerSpotRepositoryImpl(networker: networker)
     let authRepository = AuthRepositoryImpl(network: networker)
+    let userRepository = UserRepositoryImpl(network: networker)
     
     // MARK: - Flower
     
@@ -49,6 +55,12 @@ enum DependencyRegistry {
     )
     tokenDeleteUseCaseRegister(
       provider: { TokenDeleteUseCaseImpl() }
+    )
+    
+    // MARK: - User
+    
+    fetchUserInfoUseCaseRegister(
+      provider: { FetchUserInfoUseCaseImpl(reporsitory: userRepository) }
     )
     
     

--- a/Projects/PIDA/Sources/PIDAReducer.swift
+++ b/Projects/PIDA/Sources/PIDAReducer.swift
@@ -157,7 +157,11 @@ struct PIDAReducer {
         
       case .update(.delegate(.pop)):
         state.path.removeLast()
-        return .none
+        return .run { send in
+          await MainActor.run {
+            send(.setting(.checkLoggedIn))
+          }
+        }
         
         // MARK: - Auth
         

--- a/Projects/PIDA/Sources/PIDAReducer.swift
+++ b/Projects/PIDA/Sources/PIDAReducer.swift
@@ -24,6 +24,7 @@ import AuthFeatureInterface
 enum Path: Hashable {
   case setting
   case policy
+  case update
 }
 
 @Reducer
@@ -37,6 +38,7 @@ struct PIDAReducer {
     var policy = PolicyReducer.State()
     var auth = AuthReducer.State()
     var signUp = SignUpReducer.State()
+    var update = ProfileUpdateReducer.State()
     
     /// 네비게이션 이동 경로
     var path: [Path] = []
@@ -52,6 +54,7 @@ struct PIDAReducer {
     case policy(PolicyReducer.Action)
     case auth(AuthReducer.Action)
     case signUp(SignUpReducer.Action)
+    case update(ProfileUpdateReducer.Action)
     
     case binding(BindingAction<State>)
     case presentSearch(Bool)
@@ -76,6 +79,9 @@ struct PIDAReducer {
     }
     Scope(state: \.signUp, action: \.signUp) {
       SignUpReducer()
+    }
+    Scope(state: \.update, action: \.update) {
+      ProfileUpdateReducer()
     }
     
     Reduce { state, action in
@@ -117,13 +123,15 @@ struct PIDAReducer {
           }
         }
         
-        // MARK: - Map <-> Setting
+        // MARK: - Map
         
         // map -> setting
       case .map(.delegate(.pushToSetting)):
         state.path.append(.setting)
         return .none
         
+        // MARK: - Setting
+      
       case .setting(.delegate(.pop)):
         state.path.removeLast()
         return .none
@@ -133,13 +141,22 @@ struct PIDAReducer {
         state.path.append(.policy)
         return .none
         
+        // setting -> login
+        
+      case .setting(.delegate(.presentToLogin)):
+        state.isPresentAuth = true
+        return .none
+        
+      case .setting(.delegate(.presentToUpdateProfile)):
+        state.path.append(.update)
+        return .none
+        
       case .policy(.delegate(.pop)):
         state.path.removeLast()
         return .none
         
-        // setting -> login
-      case .setting(.delegate(.presentToLogin)):
-        state.isPresentAuth = true
+      case .update(.delegate(.pop)):
+        state.path.removeLast()
         return .none
         
         // MARK: - Auth
@@ -167,7 +184,7 @@ struct PIDAReducer {
         
         // MARK: - None
         
-      case .binding, .map, .search, .setting, .policy, .auth, .signUp:
+      case .binding, .map, .search, .setting, .policy, .auth, .signUp, .update:
         return .none
       }
     }

--- a/Projects/PIDA/Sources/PIDAReducer.swift
+++ b/Projects/PIDA/Sources/PIDAReducer.swift
@@ -146,7 +146,11 @@ struct PIDAReducer {
         
       case .auth(.delegate(.dismiss)):
         state.isPresentAuth = false
-        return .none
+        return .run { send in
+          await MainActor.run {
+            send(.setting(.checkLoggedIn))
+          }
+        }
         
       case .auth(.delegate(.presentToSignUp)):
         state.isPresentSignUp = true

--- a/Projects/PIDA/Sources/PIDAReducer.swift
+++ b/Projects/PIDA/Sources/PIDAReducer.swift
@@ -159,7 +159,11 @@ struct PIDAReducer {
         
       case .signUp(.delegate(.dismiss)):
         state.isPresentSignUp = false
-        return .none
+        return .run { send in
+          await MainActor.run {
+            send(.setting(.checkLoggedIn))
+          }
+        }
         
         // MARK: - None
         

--- a/Projects/PIDA/Sources/PIDAView.swift
+++ b/Projects/PIDA/Sources/PIDAView.swift
@@ -25,6 +25,8 @@ struct PIDAView: View {
             SettingView(store: store.scope(state: \.setting, action: \.setting))
           case .policy:
             PolicyView(store: store.scope(state: \.policy, action: \.policy))
+          case .update:
+            ProfileUpdateView(store: store.scope(state: \.update, action: \.update))
           }
         }
         .fullScreenCover(isPresented: $store.isPresentSignUp, content: {

--- a/Projects/Shared/Utility/Sources/Types/NicknameValidType.swift
+++ b/Projects/Shared/Utility/Sources/Types/NicknameValidType.swift
@@ -1,13 +1,12 @@
 //
-//  NickNameValidType.swift
-//  AuthFeatureInterface
+//  NicknameValidType.swift
+//  Utility
 //
-//  Created by Jiyeon on 3/27/25.
+//  Created by Jiyeon on 3/29/25.
 //  Copyright © 2025 com.yongin.pida. All rights reserved.
 //
 
 import Foundation
-
 public enum NickNameInputValid: Equatable {
   case valid
   case tooShort

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency+.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency+.swift
@@ -21,6 +21,7 @@ public enum Feature: String {
   case setting = "Setting"
   case flowerSpot = "FlowerSpot"
   case auth = "Auth"
+  case user = "User"
 }
 
 
@@ -143,6 +144,10 @@ extension TargetDependency {
       public static let Interface = Self.projectWithLayer(feature: .auth, layer: .domain)
       public static let Implement = Self.projectWithLayer(feature: .auth, layer: .domain, isInterface: false)
     }
+    public struct User: PIDADependency {
+      public static let Interface = Self.projectWithLayer(feature: .user, layer: .domain)
+      public static let Implement = Self.projectWithLayer(feature: .user, layer: .domain, isInterface: false)
+    }
   }
   
   public struct Data {
@@ -161,6 +166,10 @@ extension TargetDependency {
     public struct Auth: PIDADependency {
       public static let Interface = Self.projectWithLayer(feature: .auth, layer: .data)
       public static let Implement = Self.projectWithLayer(feature: .auth, layer: .data, isInterface: false)
+    }
+    public struct User: PIDADependency {
+      public static let Interface = Self.projectWithLayer(feature: .user, layer: .data)
+      public static let Implement = Self.projectWithLayer(feature: .user, layer: .data, isInterface: false)
     }
   }
   


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #34 

## 🔎 작업 내용
- 네트워크 헤더 타입 구현 및 토큰 헤더 추가
- 응답 성공 및 오류 로그 출력 메서드 구현
- 회원 조회 
- 로그아웃 api 연결
- 회원 탈퇴 api 연결
- 닉네임 변경 UI 및 api 연결
- 애플로그인 배경 색 변경

## 📷 스크린샷
| 닉네임 변경 | 애플로그인 배경 색 |
|:----:|:----:|
|<img src = "https://github.com/user-attachments/assets/dfcc6995-24da-4b12-993d-a70aaf7dd397" width = "300">|<img src = "https://github.com/user-attachments/assets/9b45c90c-2c70-43d4-bca9-c2747dc0618f" width = "300">|

## 🛠️ 기타 공유 내용
- 토큰을 헤더에 포함하기 위한 HeaderType을 생성하였습니다. 
- 토큰 갱신을 위한 인터셉터가 필요할 것 같아 이후 작업으로 추가하겠습니다!
