### PR TITLE
최근 검색기록 

### DIFF
--- a/Projects/Core/Cache/Sources/CacheActor.swift
+++ b/Projects/Core/Cache/Sources/CacheActor.swift
@@ -58,10 +58,10 @@ extension CacheActor {
   
   /// 외부 모듈에서 `searchHistory` 캐시에 접근할 수 있도록 제공하는 `public` extension
   /// - Note: `TwoTierCache`를 사용하여 캐시를 저장하고 관리합니다.
-  public var searchHistoryCache: TwoTierCache<Search, SearchHistoryCacheModel> {
+  public var recentSerachCache: TwoTierCache<Search, [RecentSearchItemModel]> {
     get async throws {
       return try await cache(
-        rootCacheKey: .searchHistory,
+        rootCacheKey: .recentSearchList,
         ttl: .high,
         eviction: .fifo(20)
       )

--- a/Projects/Core/Cache/Sources/CacheComponent/CacheNamespace.swift
+++ b/Projects/Core/Cache/Sources/CacheComponent/CacheNamespace.swift
@@ -13,8 +13,8 @@ public protocol CacheNamespace: RawRepresentable, Codable, Hashable where RawVal
 
 /// 기본 캐시 네임스페이스 구현
 /// - allFlowerSpotListModel: 도로명 및 주소 검색 결과
-/// - searchHistory: 최근 검색 기록
+/// - recentSearchList: 최근 검색 기록
 public enum Search: String, CacheNamespace {
   case allFlowerSpotListModel = "AllFlowerSpotListModel"
-  case searchHistory = "SearchHistory"
+  case recentSearchList = "RecentSearchList"
 }

--- a/Projects/Core/Cache/Sources/CacheModel/SearchHistoryCacheModel.swift
+++ b/Projects/Core/Cache/Sources/CacheModel/SearchHistoryCacheModel.swift
@@ -14,13 +14,13 @@ public struct RecentSearchItemModel: Codable {
   public let id: Int
   public let address: String?
   public let streetName: String?
-  public let date: Date?
+  public let date: Date
   
   public init(
     id: Int,
     address: String?,
     streetName: String?,
-    data: Date?
+    data: Date
   ) {
     self.id = id
     self.address = address

--- a/Projects/Core/Cache/Sources/CacheModel/SearchHistoryCacheModel.swift
+++ b/Projects/Core/Cache/Sources/CacheModel/SearchHistoryCacheModel.swift
@@ -10,6 +10,21 @@ import Foundation
 
 /// 검색 기록 캐시 모델(임시)
 /// - Searches: 검색 기록을 저장하는 문자열 배열입니다.
-public struct SearchHistoryCacheModel: Codable {
-  public var searches: [String]
+public struct RecentSearchItemModel: Codable {
+  public let id: Int
+  public let address: String?
+  public let streetName: String?
+  public let date: Date?
+  
+  public init(
+    id: Int,
+    address: String?,
+    streetName: String?,
+    data: Date?
+  ) {
+    self.id = id
+    self.address = address
+    self.streetName = streetName
+    self.date = data
+  }
 }

--- a/Projects/Data/Search/SearchData/Sources/SearchRepositoryImpl.swift
+++ b/Projects/Data/Search/SearchData/Sources/SearchRepositoryImpl.swift
@@ -27,4 +27,26 @@ public struct SearchRepositoryImpl: SearchRepository {
     }
     return allFlowerSpots
   }
+  
+  /// 최근 검색 기록 저장
+  public func saveRecentSearchToCache(spotItem: SearchListCellEntity) async throws -> Void {
+    let cache = try await CacheActor.shared.recentSerachCache
+    let cacheItem = RecentSearchItemModel(
+      id: spotItem.id,
+      address: spotItem.address,
+      streetName: spotItem.streetName,
+      data: Date()
+    )
+    var recentList = await cache.value(forKey: .init(.recentSearchList, "recent_search")) ?? []
+    
+    // 이미 존재하는 검색기록이면 제거 후 저장
+    if let existIndex = recentList.firstIndex(where: { $0.id == cacheItem.id }) {
+      recentList.remove(at: existIndex)
+    }
+    
+    recentList.insert(cacheItem, at: 0)
+    
+    try await cache.insert(recentList, forKey: .init(.recentSearchList, "recent_search"))
+  }
+  
 }

--- a/Projects/Data/Search/SearchData/Sources/SearchRepositoryImpl.swift
+++ b/Projects/Data/Search/SearchData/Sources/SearchRepositoryImpl.swift
@@ -49,4 +49,12 @@ public struct SearchRepositoryImpl: SearchRepository {
     try await cache.insert(recentList, forKey: .init(.recentSearchList, "recent_search"))
   }
   
+  public func fetchRecentSearchListFromCache() async throws -> [RecentSearchItemModel] {
+    let cache = try await CacheActor.shared.recentSerachCache
+    guard let item = await cache.value(forKey: .init(.recentSearchList, "recent_search")) else {
+      return []
+    }
+    return item
+  }
+  
 }

--- a/Projects/Data/Search/SearchData/Sources/SearchRepositoryImpl.swift
+++ b/Projects/Data/Search/SearchData/Sources/SearchRepositoryImpl.swift
@@ -44,6 +44,10 @@ public struct SearchRepositoryImpl: SearchRepository {
       recentList.remove(at: existIndex)
     }
     
+    if recentList.count > 20 {
+      recentList.removeLast()
+    }
+    
     recentList.insert(cacheItem, at: 0)
     
     try await cache.insert(recentList, forKey: .init(.recentSearchList, "recent_search"))

--- a/Projects/Domain/Search/SearchDomain/Sources/FetchRecentSearchUseCaseImpl.swift
+++ b/Projects/Domain/Search/SearchDomain/Sources/FetchRecentSearchUseCaseImpl.swift
@@ -1,0 +1,32 @@
+//
+//  FetchRecentSearchUseCaseImpl.swift
+//  SearchDomain
+//
+//  Created by Jiyeon on 3/31/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import SearchDomainInterface
+import Utility
+
+public struct FetchRecentSearchUseCaseImpl: FetchRecentSearchUseCase {
+  private let repository: SearchRepository
+  
+  public init(repository: SearchRepository) {
+    self.repository = repository
+  }
+  
+  public func execute() async throws -> [SearchListCellEntity] {
+    return try await repository.fetchRecentSearchListFromCache().map {
+      SearchListCellEntity(
+        id: $0.id,
+        address: $0.address,
+        streetName: $0.streetName,
+        subInfo: $0.date.toString(
+          format: .mmdd
+        )
+      )
+    }
+  }
+}

--- a/Projects/Domain/Search/SearchDomain/Sources/SaveRecentSearchItemUseCaseImpl.swift
+++ b/Projects/Domain/Search/SearchDomain/Sources/SaveRecentSearchItemUseCaseImpl.swift
@@ -1,0 +1,24 @@
+//
+//  SaveRecentSearchItemUseCaseImpl.swift
+//  SearchDomain
+//
+//  Created by Jiyeon on 3/31/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import SearchDomainInterface
+
+public struct SaveRecentSearchItemUseCaseImpl: SaveRecentSearchItemUseCase {
+  private let repository: SearchRepository
+  
+  public init(
+    repository: SearchRepository
+  ) {
+    self.repository = repository
+  }
+  
+  public func execute(spot: SearchListCellEntity) async throws {
+    try await repository.saveRecentSearchToCache(spotItem: spot)
+  }
+}

--- a/Projects/Domain/Search/SearchDomainInterface/Sources/DependencyKeys/FetchRecentSearchUseCaseKey.swift
+++ b/Projects/Domain/Search/SearchDomainInterface/Sources/DependencyKeys/FetchRecentSearchUseCaseKey.swift
@@ -1,0 +1,34 @@
+//
+//  FetchRecentSearchUseCaseKey.swift
+//  SearchDomainInterface
+//
+//  Created by Jiyeon on 3/31/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import Dependencies
+
+public enum FetchRecentSearchUseCaseKey: DependencyKey {
+  public static var liveValue: FetchRecentSearchUseCase { fetchRecentSearchItemUseCaseProvider() }
+  public static var previewValue: FetchRecentSearchUseCase { fetchRecentSearchItemUseCaseProvider() } /// TODO: Add preview value
+  public static var testValue: FetchRecentSearchUseCase { fetchRecentSearchItemUseCaseProvider() } /// TODO: Add test value
+}
+
+var fetchRecentSearchItemUseCaseProvider: () -> FetchRecentSearchUseCase = {
+  fatalError("fetchRecentSearchItemUseCase Dependency not configured")
+}
+
+public func fetchRecentSearchItemUseCaseRegister(
+  provider: @escaping () -> FetchRecentSearchUseCase
+) {
+  fetchRecentSearchItemUseCaseProvider = provider
+}
+
+extension DependencyValues {
+  public var fetchRecentSearchItemUseCase: FetchRecentSearchUseCase {
+    get { self[FetchRecentSearchUseCaseKey.self] }
+    set { self[FetchRecentSearchUseCaseKey.self] = newValue }
+  }
+}
+

--- a/Projects/Domain/Search/SearchDomainInterface/Sources/DependencyKeys/SaveRecentSearchItemUseCaseKey.swift
+++ b/Projects/Domain/Search/SearchDomainInterface/Sources/DependencyKeys/SaveRecentSearchItemUseCaseKey.swift
@@ -1,0 +1,34 @@
+//
+//  SaveRecentSearchItemUseCaseKey.swift
+//  SearchDomainInterface
+//
+//  Created by Jiyeon on 3/31/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+import Dependencies
+
+public enum SaveRecentSearchItemUseCaseKey: DependencyKey {
+  public static var liveValue: SaveRecentSearchItemUseCase { saveRecentSearchItemUseCaseProvider() }
+  public static var previewValue: SaveRecentSearchItemUseCase { saveRecentSearchItemUseCaseProvider() } /// TODO: Add preview value
+  public static var testValue: SaveRecentSearchItemUseCase { saveRecentSearchItemUseCaseProvider() } /// TODO: Add test value
+}
+
+var saveRecentSearchItemUseCaseProvider: () -> SaveRecentSearchItemUseCase = {
+  fatalError("SaveRecentSearchItemUseCase Dependency not configured")
+}
+
+public func saveRecentSearchItemUseCaseRegister(
+  provider: @escaping () -> SaveRecentSearchItemUseCase
+) {
+  saveRecentSearchItemUseCaseProvider = provider
+}
+
+extension DependencyValues {
+  public var saveRecentSearchItemUseCase: SaveRecentSearchItemUseCase {
+    get { self[SaveRecentSearchItemUseCaseKey.self] }
+    set { self[SaveRecentSearchItemUseCaseKey.self] = newValue }
+  }
+}
+

--- a/Projects/Domain/Search/SearchDomainInterface/Sources/Entity/SearchListCellEntity.swift
+++ b/Projects/Domain/Search/SearchDomainInterface/Sources/Entity/SearchListCellEntity.swift
@@ -12,14 +12,17 @@ public struct SearchListCellEntity: Equatable, Sendable {
   public let id: Int
   public let address: String?
   public let streetName: String?
+  public let subInfo: String?
   
   public init(
     id: Int,
     address: String?,
-    streetName: String?
+    streetName: String?,
+    subInfo: String? = nil
   ) {
     self.id = id
     self.address = address
     self.streetName = streetName
+    self.subInfo = subInfo
   }
 }

--- a/Projects/Domain/Search/SearchDomainInterface/Sources/Repository/SearchRepository.swift
+++ b/Projects/Domain/Search/SearchDomainInterface/Sources/Repository/SearchRepository.swift
@@ -11,4 +11,5 @@ import Cache
 
 public protocol SearchRepository {
   func getSearchListFromCache() async throws -> [AllFlowerSpotListModel]
+  func saveRecentSearchToCache(spotItem: SearchListCellEntity) async throws -> Void
 }

--- a/Projects/Domain/Search/SearchDomainInterface/Sources/Repository/SearchRepository.swift
+++ b/Projects/Domain/Search/SearchDomainInterface/Sources/Repository/SearchRepository.swift
@@ -12,4 +12,5 @@ import Cache
 public protocol SearchRepository {
   func getSearchListFromCache() async throws -> [AllFlowerSpotListModel]
   func saveRecentSearchToCache(spotItem: SearchListCellEntity) async throws -> Void
+  func fetchRecentSearchListFromCache() async throws -> [RecentSearchItemModel]
 }

--- a/Projects/Domain/Search/SearchDomainInterface/Sources/UseCase/FetchRecentSearchUseCase.swift
+++ b/Projects/Domain/Search/SearchDomainInterface/Sources/UseCase/FetchRecentSearchUseCase.swift
@@ -1,0 +1,13 @@
+//
+//  FetchRecentSearchUseCase.swift
+//  SearchDomainInterface
+//
+//  Created by Jiyeon on 3/31/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public protocol FetchRecentSearchUseCase {
+  func execute() async throws -> [SearchListCellEntity]
+}

--- a/Projects/Domain/Search/SearchDomainInterface/Sources/UseCase/SaveRecentSearchItemUseCase.swift
+++ b/Projects/Domain/Search/SearchDomainInterface/Sources/UseCase/SaveRecentSearchItemUseCase.swift
@@ -1,0 +1,13 @@
+//
+//  SaveRecentSearchItemUseCase.swift
+//  SearchDomainInterface
+//
+//  Created by Jiyeon on 3/31/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public protocol SaveRecentSearchItemUseCase {
+  func execute(spot: SearchListCellEntity) async throws
+}

--- a/Projects/Features/Search/SearchFeature/Sources/SearchReducer.swift
+++ b/Projects/Features/Search/SearchFeature/Sources/SearchReducer.swift
@@ -17,6 +17,7 @@ extension SearchReducer {
     @Dependency(\.calculateSimilarityScoreUseCase) var calculateScoreUseCase
     @Dependency(\.getSearchListFromCacheUseCase) var getSearchListFromCacheUseCase
     @Dependency(\.getFlowerSpotDetailUseCase) var getFlowerSpotDetailUseCase
+    @Dependency(\.saveRecentSearchItemUseCase) var saveRecentSearchItemUseCase
     
     let searchReducer = Reduce<State, Action> { state, action in
       switch action {
@@ -73,10 +74,11 @@ extension SearchReducer {
         }
       // MARK: - Delegate
         
-      case let .selectResult(id):
+      case let .selectResult(item):
         return .run { send in
           do {
-            let detail = try await getFlowerSpotDetailUseCase.execute(id: id)
+            let detail = try await getFlowerSpotDetailUseCase.execute(id: item.id)
+            try await saveRecentSearchItemUseCase.execute(spot: item)
             await MainActor.run {
               send(.searchBarFocused(false))
               send(.fetchSearchResult(detail))

--- a/Projects/Features/Search/SearchFeature/Sources/SearchReducer.swift
+++ b/Projects/Features/Search/SearchFeature/Sources/SearchReducer.swift
@@ -25,8 +25,33 @@ extension SearchReducer {
       case .binding(\.searchWord):
         let searchQuery = state.searchWord
         if searchQuery.isEmpty {
+          state.showRecentList = true
           return .send(.updateSearchResults(state.recentList))
+        } else {
+          state.showRecentList = false
+          return .send(.searchItem(searchQuery))
         }
+        
+      case .onAppear:
+        return .run { send in
+          await MainActor.run {
+            send(.configureSearchList)
+            send(.searchBarFocused(true))
+          }
+        }
+        
+      case .configureSearchList:
+        if state.searchWord.isEmpty {
+          state.showRecentList = true
+          return .send(.fetchRecentResult)
+        } else {
+          state.showRecentList = false
+          return .send(.searchItem(state.searchWord))
+        }
+        
+      // MARK: - Search
+        
+      case let .searchItem(searchQuery):
         return .run { send in
           do {
             let cache = try await getSearchListFromCacheUseCase.execute()
@@ -52,32 +77,11 @@ extension SearchReducer {
             print(error.localizedDescription)
           }
         }
-      case .onAppear:
-        return .run { send in
-          await MainActor.run {
-            send(.searchBarFocused(true))
-            send(.fetchRecentResult)
-          }
-        }
         
-      // MARK: - Search
-        
-      case let .searchBarFocused(isFocused):
-        state.isFocused = isFocused
-        return .none
-      case let .initialSearchBar(text): // 서치바 초기화
-        state.searchList = []
-        state.searchWord = text
-        return .none
       case let .updateSearchResults(results):
         state.searchList = results
         return .none
-      case let .fetchSearchResult(result):
-        return .run { send in
-          await MainActor.run {
-            send(.delegate(.selectResult(result)))
-          }
-        }
+        
       case .fetchRecentResult:
         return .run { send in
           do {
@@ -86,8 +90,24 @@ extension SearchReducer {
             await send(.updateSearchResults(recent))
           }
         }
+        
       case let .storeRecentResult(item):
         state.recentList = item
+        return .none
+        
+      case let .fetchSearchResult(result):
+        return .run { send in
+          await MainActor.run {
+            send(.delegate(.selectResult(result)))
+          }
+        }
+        
+      case let .searchBarFocused(isFocused):
+        state.isFocused = isFocused
+        return .none
+      case let .initialSearchBar(text): // 서치바 초기화
+        state.searchList = []
+        state.searchWord = text
         return .none
         
       // MARK: - Delegate

--- a/Projects/Features/Search/SearchFeature/Sources/SearchReducer.swift
+++ b/Projects/Features/Search/SearchFeature/Sources/SearchReducer.swift
@@ -18,11 +18,15 @@ extension SearchReducer {
     @Dependency(\.getSearchListFromCacheUseCase) var getSearchListFromCacheUseCase
     @Dependency(\.getFlowerSpotDetailUseCase) var getFlowerSpotDetailUseCase
     @Dependency(\.saveRecentSearchItemUseCase) var saveRecentSearchItemUseCase
+    @Dependency(\.fetchRecentSearchItemUseCase) var fetchRecentSearchItemUseCase
     
     let searchReducer = Reduce<State, Action> { state, action in
       switch action {
       case .binding(\.searchWord):
         let searchQuery = state.searchWord
+        if searchQuery.isEmpty {
+          return .send(.updateSearchResults(state.recentList))
+        }
         return .run { send in
           do {
             let cache = try await getSearchListFromCacheUseCase.execute()
@@ -52,6 +56,7 @@ extension SearchReducer {
         return .run { send in
           await MainActor.run {
             send(.searchBarFocused(true))
+            send(.fetchRecentResult)
           }
         }
         
@@ -61,6 +66,7 @@ extension SearchReducer {
         state.isFocused = isFocused
         return .none
       case let .initialSearchBar(text): // 서치바 초기화
+        state.searchList = []
         state.searchWord = text
         return .none
       case let .updateSearchResults(results):
@@ -72,6 +78,18 @@ extension SearchReducer {
             send(.delegate(.selectResult(result)))
           }
         }
+      case .fetchRecentResult:
+        return .run { send in
+          do {
+            let recent = try await fetchRecentSearchItemUseCase.execute()
+            await send(.storeRecentResult(recent))
+            await send(.updateSearchResults(recent))
+          }
+        }
+      case let .storeRecentResult(item):
+        state.recentList = item
+        return .none
+        
       // MARK: - Delegate
         
       case let .selectResult(item):

--- a/Projects/Features/Search/SearchFeatureInterface/Sources/Components/SearchResultList.swift
+++ b/Projects/Features/Search/SearchFeatureInterface/Sources/Components/SearchResultList.swift
@@ -17,11 +17,11 @@ import SearchDomainInterface
 public struct SearchResultList: View {
   
   private var item: SearchListCellEntity
-  private var onTap: ((Int) async -> Void)?
+  private var onTap: ((SearchListCellEntity) async -> Void)?
   
   public init(
     item: SearchListCellEntity,
-    onTap: ((Int) async -> Void)? = nil
+    onTap: ((SearchListCellEntity) async -> Void)? = nil
   ) {
     self.item = item
     
@@ -52,7 +52,7 @@ public struct SearchResultList: View {
     .onTapGesture {
       if let onTap = onTap {
         Task { @MainActor in
-          await onTap(item.id)
+          await onTap(item)
         }
       }
     }

--- a/Projects/Features/Search/SearchFeatureInterface/Sources/Components/SearchResultList.swift
+++ b/Projects/Features/Search/SearchFeatureInterface/Sources/Components/SearchResultList.swift
@@ -40,9 +40,11 @@ public struct SearchResultList: View {
             .foregroundStyle(ColorSet.Text.Tertiary)
         }
         Spacer()
-        Text("10km")
-          .fontStyle(FontSet.Caption.caption1)
-          .foregroundStyle(ColorSet.Text.Tertiary)
+        if let subInfo = item.subInfo {
+          Text(subInfo)
+            .fontStyle(FontSet.Caption.caption1)
+            .foregroundStyle(ColorSet.Text.Tertiary)
+        }
       }
       .padding(.vertical, .Number12)
       BorderView(size: .long)

--- a/Projects/Features/Search/SearchFeatureInterface/Sources/SearchReducer.swift
+++ b/Projects/Features/Search/SearchFeatureInterface/Sources/SearchReducer.swift
@@ -24,6 +24,7 @@ public struct SearchReducer {
     public var searchWord: String = ""
     public var previousWord: String = ""
     public var searchList: [SearchListCellEntity] = []
+    public var recentList: [SearchListCellEntity] = []
     public init() {}
   }
   
@@ -38,6 +39,8 @@ public struct SearchReducer {
     case initialSearchBar(String)
     case updateSearchResults([SearchListCellEntity])
     case fetchSearchResult(FlowerSpot)
+    case fetchRecentResult
+    case storeRecentResult([SearchListCellEntity])
     
     // MARK: - Delegate
     

--- a/Projects/Features/Search/SearchFeatureInterface/Sources/SearchReducer.swift
+++ b/Projects/Features/Search/SearchFeatureInterface/Sources/SearchReducer.swift
@@ -25,6 +25,7 @@ public struct SearchReducer {
     public var previousWord: String = ""
     public var searchList: [SearchListCellEntity] = []
     public var recentList: [SearchListCellEntity] = []
+    public var showRecentList: Bool = true
     public init() {}
   }
   
@@ -36,11 +37,16 @@ public struct SearchReducer {
     // MARK: - Search
     
     case searchBarFocused(Bool)
-    case initialSearchBar(String)
+    case configureSearchList
+    case searchItem(String)
+    
     case updateSearchResults([SearchListCellEntity])
     case fetchSearchResult(FlowerSpot)
     case fetchRecentResult
+    
     case storeRecentResult([SearchListCellEntity])
+    case initialSearchBar(String)
+   
     
     // MARK: - Delegate
     

--- a/Projects/Features/Search/SearchFeatureInterface/Sources/SearchReducer.swift
+++ b/Projects/Features/Search/SearchFeatureInterface/Sources/SearchReducer.swift
@@ -41,7 +41,7 @@ public struct SearchReducer {
     
     // MARK: - Delegate
     
-    case selectResult(Int)
+    case selectResult(SearchListCellEntity)
     case dismiss
     case delegate(Delegate)
   }

--- a/Projects/Features/Search/SearchFeatureInterface/Sources/SearchReducer.swift
+++ b/Projects/Features/Search/SearchFeatureInterface/Sources/SearchReducer.swift
@@ -22,7 +22,6 @@ public struct SearchReducer {
   public struct State: Equatable {
     public var isFocused: Bool = false
     public var searchWord: String = ""
-    public var previousWord: String = ""
     public var searchList: [SearchListCellEntity] = []
     public var recentList: [SearchListCellEntity] = []
     public var showRecentList: Bool = true

--- a/Projects/Features/Search/SearchFeatureInterface/Sources/SearchView.swift
+++ b/Projects/Features/Search/SearchFeatureInterface/Sources/SearchView.swift
@@ -77,9 +77,6 @@ extension SearchView {
           }
       }
     )
-    .onSubmit { 
-//      store.send(.selectResult(store.searchWord))
-    }
     
     .padding(.horizontal, .Number16)
     .padding(.vertical, .Number8)

--- a/Projects/Features/Search/SearchFeatureInterface/Sources/SearchView.swift
+++ b/Projects/Features/Search/SearchFeatureInterface/Sources/SearchView.swift
@@ -38,15 +38,25 @@ extension SearchView {
   // TODO: - 검색 데이터 확정 시 데이터에 맞춰 파라미터 추가
   /// 검색 리스트
   private func searchList() -> some View {
-    ScrollView {
-      LazyVStack {
-        ForEach(store.searchList, id: \.id) { data in
-          SearchResultList(
-            item: data,
-            onTap: {
-              store.send(.selectResult($0))
-            }
-          )
+    VStack(alignment: .leading, spacing: .Number0) {
+      if store.showRecentList {
+        Text("최근검색")
+          .fontStyle(FontSet.Body.body3)
+          .foregroundStyle(ColorSet.Text.Secondary)
+          .padding(.horizontal, .Number16)
+          .padding(.top, .Number8)
+          .padding(.bottom, .Number4)
+      }
+      ScrollView {
+        LazyVStack {
+          ForEach(store.searchList, id: \.id) { data in
+            SearchResultList(
+              item: data,
+              onTap: {
+                store.send(.selectResult($0))
+              }
+            )
+          }
         }
       }
     }

--- a/Projects/PIDA/Sources/DependencyRegister.swift
+++ b/Projects/PIDA/Sources/DependencyRegister.swift
@@ -82,6 +82,14 @@ enum DependencyRegistry {
         )
       })
     
+    fetchRecentSearchItemUseCaseRegister(
+      provider: {
+        FetchRecentSearchUseCaseImpl(
+          repository: searchRepository
+        )
+      }
+    )
+    
     // MARK: - Auth
     
     appleLoginUseCaseRegister(

--- a/Projects/PIDA/Sources/DependencyRegister.swift
+++ b/Projects/PIDA/Sources/DependencyRegister.swift
@@ -75,6 +75,13 @@ enum DependencyRegistry {
       )
     }
     
+    saveRecentSearchItemUseCaseRegister(
+      provider: {
+        SaveRecentSearchItemUseCaseImpl(
+          repository: searchRepository
+        )
+      })
+    
     // MARK: - Auth
     
     appleLoginUseCaseRegister(

--- a/Projects/Shared/Utility/Sources/Extensions/Date+.swift
+++ b/Projects/Shared/Utility/Sources/Extensions/Date+.swift
@@ -1,0 +1,35 @@
+//
+//  Date+.swift
+//  Utility
+//
+//  Created by Jiyeon on 3/31/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+/// 변경하려는 포멧 스타일 정의
+public enum DateFormatType {
+  case mmdd
+  
+  public var format: String {
+    switch self {
+    case .mmdd:
+      return "MM.dd"
+    }
+  }
+}
+
+public extension Date {
+  static func formatter(with format: DateFormatType) -> DateFormatter {
+    let formatter = DateFormatter()
+    formatter.dateFormat = format.format
+    formatter.locale = Locale(identifier: "ko")
+    return formatter
+  }
+  
+  /// Date 타입을 String으로 변경
+  func toString(format: DateFormatType) -> String {
+    return Date.formatter(with: format).string(from: self)
+  }
+}


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #40 

## 🔎 작업 내용
- 검색 시 최근 검색기록 저장
- 검색 뷰 진입 시 최근 검색기록 불러오기
- 20개 개수 제한

## 📷 스크린샷

https://github.com/user-attachments/assets/d2b2797a-2316-4663-b09a-b44d2312bbd2


## 🛠️ 기타 공유 내용
- 검색으로 지도 진입을 여러 번 할 때 이전에 검색한 핀이 사라지지 않는 문제가 있어서 이후 작업에서 수정 할 예정입니다

