### PR TITLE
feat: #58 개화상태 기록 후, 디테일 뷰 및 바텀시트 데이터 업데이트

### DIFF
--- a/Projects/Features/Blooming/BloomingFeature/Sources/BloominUpdateReducer.swift
+++ b/Projects/Features/Blooming/BloomingFeature/Sources/BloominUpdateReducer.swift
@@ -54,15 +54,15 @@ extension BloomingUpdateReducer {
         return .run { send in
           do {
             try await updateBloomingUseCase.execute(id: id, status: status.rawValue)
-            await send(.dismiss(didUpdate: true))
+            await send(.dismiss(didUpdate: true, spotId: id))
           } catch {
             await send(.sendToastMessage("기록에 실패했어요"))
           }
         }
         
-      case let .dismiss(update):
+      case let .dismiss(update, spotId):
         return .run { send in
-          await send(.delegate(.dismiss(didUpdate: update)))
+          await send(.delegate(.dismiss(didUpdate: update, spotId: spotId)))
           await send(.initialState)
         }
       case .binding, .delegate:

--- a/Projects/Features/Blooming/BloomingFeatureInterface/Sources/BloomingUpdateReducer.swift
+++ b/Projects/Features/Blooming/BloomingFeatureInterface/Sources/BloomingUpdateReducer.swift
@@ -41,11 +41,11 @@ public struct BloomingUpdateReducer {
     case setStreetName(String)
     
     case delegate(Delegate)
-    case dismiss(didUpdate: Bool) // 상태 기록 완료 여부
+    case dismiss(didUpdate: Bool, spotId: Int) // 상태 기록 완료 여부
   }
   
   public enum Delegate: Equatable {
-    case dismiss(didUpdate: Bool)
+    case dismiss(didUpdate: Bool, spotId: Int)
   }
   
   public enum ID: Hashable {

--- a/Projects/Features/Blooming/BloomingFeatureInterface/Sources/BloomingUpdateView.swift
+++ b/Projects/Features/Blooming/BloomingFeatureInterface/Sources/BloomingUpdateView.swift
@@ -47,7 +47,8 @@ public struct BloomingUpdateView: View {
       TouchArea(image: .close)
         .size(.superLarge)
         .action {
-          store.send(.dismiss(didUpdate: false))
+          guard let spotId = store.spotId else { return }
+          store.send(.dismiss(didUpdate: false, spotId: spotId))
         }
       }
     )

--- a/Projects/Features/Map/MapFeature/Sources/MapView/MapReducer.swift
+++ b/Projects/Features/Map/MapFeature/Sources/MapView/MapReducer.swift
@@ -113,17 +113,53 @@ extension MapReducer {
             print(error.localizedDescription)
           }
         }
-        
+      case let .fetchDetailInfo(id):
+        state.selectedItemDetail = nil
+        state.isNeedFetchDetail = true
+        return .run { send in
+          do {
+            async let detailResult = try await getFlowerSpotDetailUseCase.execute(id: id)
+            async let bloomingResult = try await getBloomingStateUseCase.execute(id: id)
+            let (detail, blooming) = try await (detailResult, bloomingResult)
+            await MainActor.run {
+              send(.detailResponse(detail))
+              send(.bloomingResponse(blooming))
+            }
+          } catch let error as NetworkError {
+            print(error.errorDescription)
+          } catch let error as FoundationError {
+            print(error.errorDescription)
+          } catch {
+            print(error.localizedDescription)
+          }
+        }
       case let .detailResponse(item):
         state.selectedItemDetail = item
         if state.selectedItemBlooming != nil {
           state.isDetailLoading = false
+          return .send(.allDataUpdated)
         }
         return .send(.calculateDistance(item.pinPoint))
       case let .bloomingResponse(item):
         state.selectedItemBlooming = item
         if state.selectedItemDetail != nil {
           state.isDetailLoading = false
+          return .send(.allDataUpdated)
+        }
+        return .none
+      case .allDataUpdated:
+        if state.isNeedFetchDetail {
+          if let item = state.selectedItemDetail,
+             let bloomingStatus = state.selectedItemBlooming {
+            return .send(
+              .presentToDetail(
+                flowerSpotData: item,
+                bloomingStatus: bloomingStatus,
+                distance: state.distance
+              )
+            )
+          }
+          state.isNeedFetchDetail = false
         }
         return .none
       case let .calculateDistance(pinPoint):

--- a/Projects/Features/Map/MapFeatureInterface/Sources/MapView/MapReducer.swift
+++ b/Projects/Features/Map/MapFeatureInterface/Sources/MapView/MapReducer.swift
@@ -41,6 +41,8 @@ public struct MapReducer {
     public var researchButtonEnable: Bool = false
     /// 현재 위치에서 특정 지점까지의 거리 (단위: 킬로미터)
     public var distance: Double = .zero
+    /// DetailView가 fetch가 필요한 지 여부 flag
+    public var isNeedFetchDetail: Bool = false
     
     /// 검색 결과 데이터
     public var searchResult: FlowerSpot? = nil
@@ -80,12 +82,15 @@ public struct MapReducer {
     case markerTapped(id: Int?)
     case detailResponse(FlowerSpot)
     case bloomingResponse(BloomStatusEntity)
+    case allDataUpdated
     case fetchPathLines(Int)
     case requestMapBounds(Bool)
     case mapSearchError(String?)
     case selectedItem(FlowerSpot)
     case dismissBottomSheet
     case requestDetailInfo(Int)
+    case fetchDetailInfo(Int)
+    
     
     case calculateDistance(MapPoint)
     

--- a/Projects/PIDA/Sources/PIDAReducer.swift
+++ b/Projects/PIDA/Sources/PIDAReducer.swift
@@ -178,11 +178,11 @@ struct PIDAReducer {
       case .flowerSpotDetail(.delegate(.presentToLogin)):
         state.isPresentAuth = true
         return .none
-      case let .blooming(.delegate(.dismiss(didUpdate))):
-        print("기록 완료 여부 ", didUpdate)
+      case let .blooming(.delegate(.dismiss(didUpdate, spotId))):
         return .run { send in
           await send(.presentBloomingUpdate(false))
           if didUpdate {
+            await send(.map(.fetchDetailInfo(spotId)))
             try? await Task.sleep(for: .seconds(0.3))
             await send(.flowerSpotDetail(.showToastView(message: "오늘의 개화 상태가 기록되었습니다.")))
           }


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #58

## 🔎 작업 내용
- 개화상태를 업데이트 하고, DetailView 및 바텀시트의 정보를 업데이트 합니다.
## 📷 스크린샷

https://github.com/user-attachments/assets/0a54c931-be61-4def-8e4b-2630fe029f56


## 🛠️ 기타 공유 내용
- Marker는 부탁해용
