### PR TITLE
MapReducer 구조 분리작업

### DIFF
--- a/Projects/Features/Map/MapFeature/Sources/MapView/DetailReducer.swift
+++ b/Projects/Features/Map/MapFeature/Sources/MapView/DetailReducer.swift
@@ -25,15 +25,15 @@ extension MapReducer {
       switch action {
       
       case let .selectedItem(item):
-        state.selectedItem = item
+        state.detail.selectedItem = item
         return .send(.fetchPathLines(item.id))
         
       case let .requestDetailInfo(id):
-        state.selectedItemDetail = nil
-        state.selectedItemBlooming = nil
-        state.selectedItemVote = nil
-        state.isDetailLoading = true
-        state.isBottomSheetPresented = true
+        state.detail.selectedItemDetail = nil
+        state.detail.selectedItemBlooming = nil
+        state.detail.selectedItemVote = nil
+        state.detail.isDetailLoading = true
+        state.detail.isBottomSheetPresented = true
         return .run { send in
           do {
             async let detailResult = try getFlowerSpotDetailUseCase.execute(id: id)
@@ -57,10 +57,10 @@ extension MapReducer {
         }
         
       case let .fetchDetailInfo(id):
-        state.selectedItemDetail = nil
-        state.selectedItemBlooming = nil
-        state.selectedItemVote = nil
-        state.isNeedFetchDetail = true
+        state.detail.selectedItemDetail = nil
+        state.detail.selectedItemBlooming = nil
+        state.detail.selectedItemVote = nil
+        state.detail.isNeedFetchDetail = true
         return .run { send in
           do {
             async let detailResult = try await getFlowerSpotDetailUseCase.execute(id: id)
@@ -82,32 +82,32 @@ extension MapReducer {
         }
         
       case let .detailResponse(item):
-        state.selectedItemDetail = item
+        state.detail.selectedItemDetail = item
         return .send(.calculateDistance(item.pinPoint))
         
       case let .bloomingResponse(item):
-        state.selectedItemBlooming = item
-        if state.selectedItemDetail != nil && state.selectedItemVote != nil {
-          state.isDetailLoading = false
+        state.detail.selectedItemBlooming = item
+        if state.detail.selectedItemDetail != nil && state.detail.selectedItemVote != nil {
+          state.detail.isDetailLoading = false
           return .send(.allDataUpdated)
         }
         return .none
         
       case let .verifyTodayBlooming(item):
-        state.selectedItemVote = item
-        if state.selectedItemDetail != nil && state.selectedItemBlooming != nil {
-          state.isDetailLoading = false
+        state.detail.selectedItemVote = item
+        if state.detail.selectedItemDetail != nil && state.detail.selectedItemBlooming != nil {
+          state.detail.isDetailLoading = false
           return .send(.allDataUpdated)
         }
         return .none
         
       case .allDataUpdated:
-        if state.isNeedFetchDetail {
-          state.isNeedFetchDetail = false
-          if let item = state.selectedItemDetail,
-             let bloomingStatus = state.selectedItemBlooming,
-             let isVotedBlooming = state.selectedItemVote {
-            return .run { [distance = state.distance] send in
+        if state.detail.isNeedFetchDetail {
+          state.detail.isNeedFetchDetail = false
+          if let item = state.detail.selectedItemDetail,
+             let bloomingStatus = state.detail.selectedItemBlooming,
+             let isVotedBlooming = state.detail.selectedItemVote {
+            return .run { [distance = state.detail.distance] send in
               await send(.updateMarkerStatus(item.bloomingStatus, id: item.id))
               await send(
                 .presentToDetail(
@@ -124,12 +124,12 @@ extension MapReducer {
         
       case let .calculateDistance(pinPoint):
         guard let userPoint = state.userLocation else {
-          state.distance = .zero
+          state.detail.distance = .zero
           return .none
         }
-        state.distance = pinPoint.distance(from: userPoint)
-        if state.selectedItemBlooming != nil && state.selectedItemVote != nil {
-          state.isDetailLoading = false
+        state.detail.distance = pinPoint.distance(from: userPoint)
+        if state.detail.selectedItemBlooming != nil && state.detail.selectedItemVote != nil {
+          state.detail.isDetailLoading = false
           return .send(.allDataUpdated)
         }
         return .none
@@ -140,14 +140,14 @@ extension MapReducer {
         } else if state.searchResult != .none {
           state.searchResult?.bloomingStatus = status
         }
-        state.updateMarkerStatus = status
+        state.detail.updateMarkerStatus = status
         return .none
         
       case .dismissBottomSheet:
-        state.isBottomSheetPresented = false
-        state.selectedItemDetail = nil
-        state.selectedItemBlooming = nil
-        state.distance = .zero
+        state.detail.isBottomSheetPresented = false
+        state.detail.selectedItemDetail = nil
+        state.detail.selectedItemBlooming = nil
+        state.detail.distance = .zero
         return .none
         
         // 부모 리듀서에 전달 할 액션

--- a/Projects/Features/Map/MapFeature/Sources/MapView/DetailReducer.swift
+++ b/Projects/Features/Map/MapFeature/Sources/MapView/DetailReducer.swift
@@ -1,0 +1,158 @@
+//
+//  DetailReducer.swift
+//  MapFeature
+//
+//  Created by Jiyeon on 4/7/25.
+//  Copyright © 2025 com.pida.me.ios. All rights reserved.
+//
+
+import MapFeatureInterface
+import FlowerSpotDomainInterface
+import BloomingDomainInterface
+import ComposableArchitecture
+import Utility
+import UserDefault
+
+extension MapReducer {
+  
+  struct DetailReducer: Reducer {
+    
+    @Dependency(\.getFlowerSpotDetailUseCase) var getFlowerSpotDetailUseCase
+    @Dependency(\.getBloomingStateUseCase) var getBloomingStateUseCase
+    @Dependency(\.verifyBloomingTodayUseCase) var verifyBloomingTodayUseCase
+    
+    func reduce(into state: inout State, action: DetailAction) -> Effect<DetailAction> {
+      switch action {
+      
+      case let .selectedItem(item):
+        state.selectedItem = item
+        return .send(.fetchPathLines(item.id))
+        
+      case let .requestDetailInfo(id):
+        state.selectedItemDetail = nil
+        state.selectedItemBlooming = nil
+        state.selectedItemVote = nil
+        state.isDetailLoading = true
+        state.isBottomSheetPresented = true
+        return .run { send in
+          do {
+            async let detailResult = try getFlowerSpotDetailUseCase.execute(id: id)
+            async let bloomingResult = try getBloomingStateUseCase.execute(id: id)
+            let verifyTodayResult = UserDefault.isLoggedIn == true
+            ? try await verifyBloomingTodayUseCase.execute(id: id)
+            : VerifyBloomingStateEntity(isBlooming: false)
+            let (detail, blooming) = try await (detailResult, bloomingResult)
+            await MainActor.run {
+              send(.detailResponse(detail))
+              send(.bloomingResponse(blooming))
+              send(.verifyTodayBlooming(verifyTodayResult))
+            }
+          } catch let error as NetworkError {
+            print(error.errorDescription)
+          } catch let error as FoundationError {
+            print(error.errorDescription)
+          } catch {
+            print(error.localizedDescription)
+          }
+        }
+        
+      case let .fetchDetailInfo(id):
+        state.selectedItemDetail = nil
+        state.selectedItemBlooming = nil
+        state.selectedItemVote = nil
+        state.isNeedFetchDetail = true
+        return .run { send in
+          do {
+            async let detailResult = try await getFlowerSpotDetailUseCase.execute(id: id)
+            async let bloomingResult = try await getBloomingStateUseCase.execute(id: id)
+            async let verifyTodayResult = try await verifyBloomingTodayUseCase.execute(id: id)
+            let (detail, blooming, verifyToday) = try await (detailResult, bloomingResult, verifyTodayResult)
+            await MainActor.run {
+              send(.detailResponse(detail))
+              send(.bloomingResponse(blooming))
+              send(.verifyTodayBlooming(verifyToday))
+            }
+          } catch let error as NetworkError {
+            print(error.errorDescription)
+          } catch let error as FoundationError {
+            print(error.errorDescription)
+          } catch {
+            print(error.localizedDescription)
+          }
+        }
+        
+      case let .detailResponse(item):
+        state.selectedItemDetail = item
+        return .send(.calculateDistance(item.pinPoint))
+        
+      case let .bloomingResponse(item):
+        state.selectedItemBlooming = item
+        if state.selectedItemDetail != nil && state.selectedItemVote != nil {
+          state.isDetailLoading = false
+          return .send(.allDataUpdated)
+        }
+        return .none
+        
+      case let .verifyTodayBlooming(item):
+        state.selectedItemVote = item
+        if state.selectedItemDetail != nil && state.selectedItemBlooming != nil {
+          state.isDetailLoading = false
+          return .send(.allDataUpdated)
+        }
+        return .none
+        
+      case .allDataUpdated:
+        if state.isNeedFetchDetail {
+          state.isNeedFetchDetail = false
+          if let item = state.selectedItemDetail,
+             let bloomingStatus = state.selectedItemBlooming,
+             let isVotedBlooming = state.selectedItemVote {
+            return .run { [distance = state.distance] send in
+              await send(.updateMarkerStatus(item.bloomingStatus, id: item.id))
+              await send(
+                .presentToDetail(
+                  flowerSpotData: item,
+                  bloomingStatus: bloomingStatus,
+                  distance: distance,
+                  isVotedBlooming: isVotedBlooming
+                )
+              )
+            }
+          }
+        }
+        return .none
+        
+      case let .calculateDistance(pinPoint):
+        guard let userPoint = state.userLocation else {
+          state.distance = .zero
+          return .none
+        }
+        state.distance = pinPoint.distance(from: userPoint)
+        if state.selectedItemBlooming != nil && state.selectedItemVote != nil {
+          state.isDetailLoading = false
+          return .send(.allDataUpdated)
+        }
+        return .none
+        
+      case let .updateMarkerStatus(status, id):
+        if state.flowerSpots[id] != .none {
+          state.flowerSpots[id]?.bloomingStatus = status
+        } else if state.searchResult != .none {
+          state.searchResult?.bloomingStatus = status
+        }
+        state.updateMarkerStatus = status
+        return .none
+        
+      case .dismissBottomSheet:
+        state.isBottomSheetPresented = false
+        state.selectedItemDetail = nil
+        state.selectedItemBlooming = nil
+        state.distance = .zero
+        return .none
+        
+        // 부모 리듀서에 전달 할 액션
+      case .presentToDetail, .fetchPathLines: return .none
+      }
+    }
+  }
+}

--- a/Projects/Features/Map/MapFeature/Sources/MapView/LocationReducer.swift
+++ b/Projects/Features/Map/MapFeature/Sources/MapView/LocationReducer.swift
@@ -1,0 +1,52 @@
+//
+//  locationReducer.swift
+//  MapFeature
+//
+//  Created by Jiyeon on 4/7/25.
+//  Copyright © 2025 com.pida.me.ios. All rights reserved.
+//
+
+import MapFeatureInterface
+import FlowerSpotDomainInterface
+import ComposableArchitecture
+import Utility
+
+extension MapReducer {
+  struct LocationReducer: Reducer {
+    public func reduce(into state: inout LocationState, action: LocationAction) -> Effect<LocationAction> {
+      
+      switch action {
+      case .fetchUserLocation:
+        let point = state.point
+        return .run { send in
+          await LocationService.shared.requestUserLocation()
+          if let point = point {
+            await MainActor.run {
+              send(.moveLocation(point))  // 현재 저장된 위치로 이동
+            }
+            
+          }
+        }
+        
+      case .moveUserLocation:
+        return .run { send in
+          if let location = await LocationService.shared.userLocation {
+            let userLocation = MapPoint(latitude: location.0, longitude: location.1)
+            await send(.saveUserLocation(userLocation))
+            await send(.moveLocation(userLocation))
+          }
+        }
+        
+      case let .saveUserLocation(location):
+        state.userLocation = location
+        return .none
+        
+      case let .moveLocation(point):
+        state.point = point
+        return .none
+        
+      }
+    }
+  }
+  
+}

--- a/Projects/Features/Map/MapFeature/Sources/MapView/LocationReducer.swift
+++ b/Projects/Features/Map/MapFeature/Sources/MapView/LocationReducer.swift
@@ -13,6 +13,9 @@ import Utility
 
 extension MapReducer {
   struct LocationReducer: Reducer {
+    
+    @Dependency(\.fetchAllFlowerPinUseCase) var fetchAllFlowerPinUseCase
+    
     public func reduce(into state: inout State, action: LocationAction) -> Effect<LocationAction> {
       
       switch action {
@@ -49,6 +52,43 @@ extension MapReducer {
         state.requestMapBound = isRequest
         state.researchButtonEnable = false
         return .none
+        
+      case let .fetchFlowers(positions):
+        return .run { send in
+          do {
+            let result = try await fetchAllFlowerPinUseCase.execute(
+              region: "SEOUL",
+              swLat: positions[0].latitude,
+              swLng: positions[0].longitude,
+              neLat: positions[1].latitude,
+              neLng: positions[1].longitude
+            )
+            if result.count == 0 {
+              await send(.showToastView(message: "이 근방에는 꽃길이 없어요."))
+            }
+            await send(.storeFlowerData(result))
+          } catch let error as NetworkError {
+            await send(.mapSearchError(error.localizedDescription))
+          } catch let error as FoundationError {
+            await send(.mapSearchError(error.localizedDescription))
+          } catch {
+            await send(.mapSearchError(error.localizedDescription))
+          }
+        }
+      case let .storeFlowerData(data):
+        state.flowerSpots.removeAll()
+        data.forEach {
+          state.flowerSpots[$0.id] = $0
+        }
+        return .none
+        
+      case let .mapSearchError(error):
+        print("=============")
+        print(error ?? "ERROR!")
+        print("=============")
+        return .none
+        
+      case .showToastView: return .none
         
       }
     }

--- a/Projects/Features/Map/MapFeature/Sources/MapView/LocationReducer.swift
+++ b/Projects/Features/Map/MapFeature/Sources/MapView/LocationReducer.swift
@@ -13,7 +13,7 @@ import Utility
 
 extension MapReducer {
   struct LocationReducer: Reducer {
-    public func reduce(into state: inout LocationState, action: LocationAction) -> Effect<LocationAction> {
+    public func reduce(into state: inout State, action: LocationAction) -> Effect<LocationAction> {
       
       switch action {
       case .fetchUserLocation:
@@ -43,6 +43,11 @@ extension MapReducer {
         
       case let .moveLocation(point):
         state.point = point
+        return .none
+        
+      case let .requestMapBounds(isRequest):
+        state.requestMapBound = isRequest
+        state.researchButtonEnable = false
         return .none
         
       }

--- a/Projects/Features/Map/MapFeature/Sources/MapView/MapReducer.swift
+++ b/Projects/Features/Map/MapFeature/Sources/MapView/MapReducer.swift
@@ -21,41 +21,12 @@ extension MapReducer {
     @Dependency(\.getBloomingStateUseCase) var getBloomingStateUseCase
     @Dependency(\.verifyBloomingTodayUseCase) var verifyBloomingTodayUseCase
     
-    let mapReducer = Reduce<State, Action> {
-      state,
-      action in
+    let mapReducer = Reduce<State, Action> { state, action in
+        
       switch action {
         
       case let .showToastView(message):
         state.toastMessage = message
-        return .none
-        
-        // MARK: - Map
-        
-      case .fetchUserLocation:
-        let point = state.point
-        return .run { send in
-          await LocationService.shared.requestUserLocation()
-          if let point = point {
-            await send(.moveLocation(point))  // 현재 저장된 위치로 이동
-          }
-        }
-        
-      case .moveUserLocation:
-        return .run { send in
-          if let location = await LocationService.shared.userLocation {
-            let userLocation = MapPoint(latitude: location.0, longitude: location.1)
-            await send(.saveUserLocation(userLocation))
-            await send(.moveLocation(userLocation))
-          }
-        }
-        
-      case let .saveUserLocation(location):
-        state.userLocation = location
-        return .none
-        
-      case let .moveLocation(point):
-        state.point = point
         return .none
         
       case let .fetchFlowers(positions):
@@ -156,7 +127,7 @@ extension MapReducer {
         return .send(.calculateDistance(item.pinPoint))
         
       case let .calculateDistance(pinPoint):
-        guard let userPoint = state.userLocation else {
+        guard let userPoint = state.location.userLocation else {
           state.distance = .zero
           return .none
         }
@@ -269,7 +240,7 @@ extension MapReducer {
         return .run { send in
           if let result = result {
             await send(.setSearchBarText(result.streetName))
-            await send(.moveLocation(result.pinPoint))
+            await send(.location(.moveLocation(result.pinPoint)))
             await send(.fetchPathLines(result.id))
             await send(.requestDetailInfo(result.id))
           }
@@ -292,8 +263,10 @@ extension MapReducer {
         
       case .presentToSearch:
         return .send(.delegate(.presentToSearch(state.searchText)))
+        
       case .pushToSetting:
         return .send(.delegate(.pushToSetting))
+        
       case let .presentToDetail(flowerSpot, bloomingStatus, distance, isVotedBlooming):
         return .send(
           .delegate(
@@ -307,12 +280,13 @@ extension MapReducer {
         )
         // MARK: - None
         
-      case .binding,
-          .delegate:
+      case .binding, .delegate, .location:
         return .none
+        
       }
+    
     }
-    self.init(reducer: mapReducer)
+    self.init(reducer: mapReducer, location: Reduce(LocationReducer()))
     
   }
 }

--- a/Projects/Features/Map/MapFeature/Sources/MapView/MapReducer.swift
+++ b/Projects/Features/Map/MapFeature/Sources/MapView/MapReducer.swift
@@ -17,16 +17,46 @@ extension MapReducer {
   public init() {
     @Dependency(\.fetchAllFlowerPinUseCase) var fetchAllFlowerPinUseCase
     @Dependency(\.fetchAllFlowerAddressUseCase) var fetchAllFlowerAddressUseCase
-    @Dependency(\.getFlowerSpotDetailUseCase) var getFlowerSpotDetailUseCase
-    @Dependency(\.getBloomingStateUseCase) var getBloomingStateUseCase
-    @Dependency(\.verifyBloomingTodayUseCase) var verifyBloomingTodayUseCase
     
     let mapReducer = Reduce<State, Action> { state, action in
-        
       switch action {
-        
       case let .showToastView(message):
         state.toastMessage = message
+        return .none
+        
+      case .viewDidAppear:
+        state.isViewAppeared = true
+        return .run { send in
+          do {
+            let _ = try await fetchAllFlowerAddressUseCase.execute()
+          } catch let error as NetworkError {
+            await send(.mapSearchError(error.localizedDescription))
+          } catch let error as FoundationError {
+            await send(.mapSearchError(error.localizedDescription))
+          } catch {
+            await send(.mapSearchError(error.localizedDescription))
+          }
+          await send(.location(.requestMapBounds(true)))
+        }
+        
+        // 마커 탭 시, 디테일정보 불러오기 및 바텀시트 on
+      case let .markerTapped(id):
+        guard let id = id else {
+          state.isNeedDeleteMarker = true
+          return .none
+        }
+        return .run { send in
+          await send(.fetchPathLines(id))
+          await send(.detail(.requestDetailInfo(id)))
+        }
+        
+      case let .fetchPathLines(id):
+        if let data = state.flowerSpots[id] {
+          state.selectedPathLines = data.path
+          state.isNeedDrawMarker = true
+        } else {
+          state.selectedPathLines = []
+        }
         return .none
         
       case let .fetchFlowers(positions):
@@ -58,181 +88,17 @@ extension MapReducer {
         }
         return .none
         
-        // 마커 탭 시, 디테일정보 불러오기 및 바텀시트 on
-      case let .markerTapped(id):
-        guard let id = id else {
-          state.isNeedDeleteMarker = true
-          return .none
-        }
-        return .run { send in
-          await send(.fetchPathLines(id))
-          await send(.requestDetailInfo(id))
-        }
-        
-      case let .requestDetailInfo(id):
-        state.selectedItemDetail = nil
-        state.selectedItemBlooming = nil
-        state.selectedItemVote = nil
-        state.isDetailLoading = true
-        state.isBottomSheetPresented = true
-        return .run { send in
-          do {
-            async let detailResult = try getFlowerSpotDetailUseCase.execute(id: id)
-            async let bloomingResult = try getBloomingStateUseCase.execute(id: id)
-            let verifyTodayResult = UserDefault.isLoggedIn == true
-            ? try await verifyBloomingTodayUseCase.execute(id: id)
-            : VerifyBloomingStateEntity(isBlooming: false)
-            let (detail, blooming) = try await (detailResult, bloomingResult)
-            await MainActor.run {
-                send(.detailResponse(detail))
-                send(.bloomingResponse(blooming))
-                send(.verifyTodayBlooming(verifyTodayResult))
-            }
-          } catch let error as NetworkError {
-            print(error.errorDescription)
-          } catch let error as FoundationError {
-            print(error.errorDescription)
-          } catch {
-            print(error.localizedDescription)
-          }
-        }
-        
-      case let .fetchDetailInfo(id):
-        state.selectedItemDetail = nil
-        state.selectedItemBlooming = nil
-        state.selectedItemVote = nil
-        state.isNeedFetchDetail = true
-        return .run { send in
-          do {
-            async let detailResult = try await getFlowerSpotDetailUseCase.execute(id: id)
-            async let bloomingResult = try await getBloomingStateUseCase.execute(id: id)
-            async let verifyTodayResult = try await verifyBloomingTodayUseCase.execute(id: id)
-            let (detail, blooming, verifyToday) = try await (detailResult, bloomingResult, verifyTodayResult)
-            await MainActor.run {
-              send(.detailResponse(detail))
-              send(.bloomingResponse(blooming))
-              send(.verifyTodayBlooming(verifyToday))
-            }
-          } catch let error as NetworkError {
-            print(error.errorDescription)
-          } catch let error as FoundationError {
-            print(error.errorDescription)
-          } catch {
-            print(error.localizedDescription)
-          }
-        }
-        
-      case let .detailResponse(item):
-        state.selectedItemDetail = item
-        return .send(.calculateDistance(item.pinPoint))
-        
-      case let .calculateDistance(pinPoint):
-        guard let userPoint = state.location.userLocation else {
-          state.distance = .zero
-          return .none
-        }
-        state.distance = pinPoint.distance(from: userPoint)
-        if state.selectedItemBlooming != nil && state.selectedItemVote != nil {
-          state.isDetailLoading = false
-          return .send(.allDataUpdated)
-        }
-        return .none
-        
-      case let .bloomingResponse(item):
-        state.selectedItemBlooming = item
-        if state.selectedItemDetail != nil && state.selectedItemVote != nil {
-          state.isDetailLoading = false
-          return .send(.allDataUpdated)
-        }
-        return .none
-        
-      case let .verifyTodayBlooming(item):
-        state.selectedItemVote = item
-        if state.selectedItemDetail != nil && state.selectedItemBlooming != nil {
-          state.isDetailLoading = false
-          return .send(.allDataUpdated)
-        }
-        return .none
-        
-      case .allDataUpdated:
-        if state.isNeedFetchDetail {
-          state.isNeedFetchDetail = false
-          if let item = state.selectedItemDetail,
-             let bloomingStatus = state.selectedItemBlooming,
-             let isVotedBlooming = state.selectedItemVote {
-            return .run { [distance = state.distance] send in
-              await send(.updateMarkerStatus(item.bloomingStatus, id: item.id))
-              await send(
-                .presentToDetail(
-                  flowerSpotData: item,
-                  bloomingStatus: bloomingStatus,
-                  distance: distance,
-                  isVotedBlooming: isVotedBlooming
-                )
-              )
-            }
-          }
-        }
-        return .none
-        
-      case let .updateMarkerStatus(status, id):
-        if state.flowerSpots[id] != .none {
-          state.flowerSpots[id]?.bloomingStatus = status
-        } else if state.searchResult != .none {
-          state.searchResult?.bloomingStatus = status
-        }
-        state.updateMarkerStatus = status
-        return .none
-        
-      case let .fetchPathLines(id):
-        if let data = state.flowerSpots[id] {
-          state.selectedPathLines = data.path
-          state.isNeedDrawMarker = true
-        } else {
-          state.selectedPathLines = []
-        }
-        return .none
-        
       case let .mapSearchError(error):
         print("=============")
         print(error ?? "ERROR!")
         print("=============")
         return .none
         
-      case let .requestMapBounds(isRequest):
-        state.requestMapBound = isRequest
-        state.researchButtonEnable = false
-        return .none
-        
-      case let .selectedItem(item):
-        state.selectedItem = item
-        return .send(.fetchPathLines(item.id))
-        
-      case .dismissBottomSheet:
-        state.isBottomSheetPresented = false
-        state.selectedItemDetail = nil
-        state.selectedItemBlooming = nil
-        state.distance = .zero
-        return .none
-        
-      case .viewDidAppear:
-        state.isViewAppeared = true
-        return .run { send in
-          do {
-            let _ = try await fetchAllFlowerAddressUseCase.execute()
-          } catch let error as NetworkError {
-            await send(.mapSearchError(error.localizedDescription))
-          } catch let error as FoundationError {
-            await send(.mapSearchError(error.localizedDescription))
-          } catch {
-            await send(.mapSearchError(error.localizedDescription))
-          }
-          await send(.requestMapBounds(true))
-        }
+      case let .fetchDetailInfo(id):
+        return .send(.detail(.fetchDetailInfo(id)))
         
         // MARK: - Search
         
-        // 검색 결과
       case let .showSearchResult(result):
         state.searchResult = result
         state.selectedItemDetail = nil
@@ -242,7 +108,7 @@ extension MapReducer {
             await send(.setSearchBarText(result.streetName))
             await send(.location(.moveLocation(result.pinPoint)))
             await send(.fetchPathLines(result.id))
-            await send(.requestDetailInfo(result.id))
+            await send(.detail(.requestDetailInfo(result.id)))
           }
         }
         
@@ -267,7 +133,7 @@ extension MapReducer {
       case .pushToSetting:
         return .send(.delegate(.pushToSetting))
         
-      case let .presentToDetail(flowerSpot, bloomingStatus, distance, isVotedBlooming):
+      case let .detail(.presentToDetail(flowerSpot, bloomingStatus, distance, isVotedBlooming)):
         return .send(
           .delegate(
             .presentToDetail(
@@ -278,15 +144,21 @@ extension MapReducer {
             )
           )
         )
-        // MARK: - None
         
-      case .binding, .delegate, .location:
+      case let .detail(.fetchPathLines(id)):
+        return .send(.fetchPathLines(id))
+        
+      case .binding, .delegate, .location, .detail:
         return .none
         
       }
     
     }
-    self.init(reducer: mapReducer, location: Reduce(LocationReducer()))
+    self.init(
+      reducer: mapReducer,
+      location: Reduce(LocationReducer()),
+      detail: Reduce(DetailReducer())
+    )
     
   }
 }

--- a/Projects/Features/Map/MapFeature/Sources/MapView/MapReducer.swift
+++ b/Projects/Features/Map/MapFeature/Sources/MapView/MapReducer.swift
@@ -15,11 +15,11 @@ import Utility
 
 extension MapReducer {
   public init() {
-    @Dependency(\.fetchAllFlowerPinUseCase) var fetchAllFlowerPinUseCase
     @Dependency(\.fetchAllFlowerAddressUseCase) var fetchAllFlowerAddressUseCase
     
     let mapReducer = Reduce<State, Action> { state, action in
       switch action {
+        
       case let .showToastView(message):
         state.toastMessage = message
         return .none
@@ -30,11 +30,11 @@ extension MapReducer {
           do {
             let _ = try await fetchAllFlowerAddressUseCase.execute()
           } catch let error as NetworkError {
-            await send(.mapSearchError(error.localizedDescription))
+            print(error.localizedDescription)
           } catch let error as FoundationError {
-            await send(.mapSearchError(error.localizedDescription))
+            print(error.localizedDescription)
           } catch {
-            await send(.mapSearchError(error.localizedDescription))
+            print(error.localizedDescription)
           }
           await send(.location(.requestMapBounds(true)))
         }
@@ -58,42 +58,7 @@ extension MapReducer {
           state.selectedPathLines = []
         }
         return .none
-        
-      case let .fetchFlowers(positions):
-        return .run { send in
-          do {
-            let result = try await fetchAllFlowerPinUseCase.execute(
-              region: "SEOUL",
-              swLat: positions[0].latitude,
-              swLng: positions[0].longitude,
-              neLat: positions[1].latitude,
-              neLng: positions[1].longitude
-            )
-            if result.count == 0 {
-              await send(.showToastView(message: "이 근방에는 꽃길이 없어요."))
-            }
-            await send(.storeFlowerData(result))
-          } catch let error as NetworkError {
-            await send(.mapSearchError(error.localizedDescription))
-          } catch let error as FoundationError {
-            await send(.mapSearchError(error.localizedDescription))
-          } catch {
-            await send(.mapSearchError(error.localizedDescription))
-          }
-        }
-      case let .storeFlowerData(data):
-        state.flowerSpots.removeAll()
-        data.forEach {
-          state.flowerSpots[$0.id] = $0
-        }
-        return .none
-        
-      case let .mapSearchError(error):
-        print("=============")
-        print(error ?? "ERROR!")
-        print("=============")
-        return .none
-        
+      
       case let .fetchDetailInfo(id):
         return .send(.detail(.fetchDetailInfo(id)))
         
@@ -101,8 +66,8 @@ extension MapReducer {
         
       case let .showSearchResult(result):
         state.searchResult = result
-        state.selectedItemDetail = nil
-        state.isDetailLoading = true
+        state.detail.selectedItemDetail = nil
+        state.detail.isDetailLoading = true
         return .run { send in
           if let result = result {
             await send(.setSearchBarText(result.streetName))
@@ -147,6 +112,9 @@ extension MapReducer {
         
       case let .detail(.fetchPathLines(id)):
         return .send(.fetchPathLines(id))
+        
+      case let .location(.showToastView(message)):
+        return .send(.showToastView(message: message))
         
       case .binding, .delegate, .location, .detail:
         return .none

--- a/Projects/Features/Map/MapFeatureInterface/Sources/MapView/DetailReducer.swift
+++ b/Projects/Features/Map/MapFeatureInterface/Sources/MapView/DetailReducer.swift
@@ -1,0 +1,59 @@
+//
+//  DetailReducer.swift
+//  MapFeature
+//
+//  Created by Jiyeon on 4/7/25.
+//  Copyright © 2025 com.pida.me.ios. All rights reserved.
+//
+
+import FlowerSpotDomainInterface
+import BloomingDomainInterface
+import ComposableArchitecture
+import DesignKit
+
+extension MapReducer {
+  
+  public struct DetailState: Equatable {
+    public var selectedItem: FlowerSpot? = nil
+    /// 네트워크로 받아온 상세 데이터
+    public var selectedItemDetail: FlowerSpot? = nil
+    /// 네트워크로 받아온 개화 상태 데이터
+    public var selectedItemBlooming: BloomStatusEntity? = nil
+    /// 네트워크로 받아온 투표 상태 데이터
+    public var selectedItemVote: VerifyBloomingStateEntity? = nil
+    /// 로딩 여부
+    public var isDetailLoading: Bool = false
+    /// DetailView가 fetch가 필요한 지 여부 flag
+    public var isNeedFetchDetail: Bool = false
+    /// 현재 위치에서 특정 지점까지의 거리 (단위: 킬로미터)
+    public var distance: Double = .zero
+    /// 바텀시트 띄우기 트리거
+    public var isBottomSheetPresented: Bool = false
+    
+    public var updateMarkerStatus: BloomStatus? = nil
+  }
+  
+  public enum DetailAction: Equatable {
+    case fetchPathLines(Int)
+    case selectedItem(FlowerSpot)
+    
+    case requestDetailInfo(Int)
+    case fetchDetailInfo(Int)
+    
+    case detailResponse(FlowerSpot)
+    case bloomingResponse(BloomStatusEntity)
+    case verifyTodayBlooming(VerifyBloomingStateEntity)
+    case allDataUpdated
+    
+    case calculateDistance(MapPoint)
+    case updateMarkerStatus(BloomStatus, id: Int)
+    case dismissBottomSheet
+    case presentToDetail(
+      flowerSpotData: FlowerSpot,
+      bloomingStatus: BloomStatusEntity,
+      distance: Double,
+      isVotedBlooming: VerifyBloomingStateEntity
+    )
+  }
+  
+}

--- a/Projects/Features/Map/MapFeatureInterface/Sources/MapView/LocationReducer.swift
+++ b/Projects/Features/Map/MapFeatureInterface/Sources/MapView/LocationReducer.swift
@@ -1,0 +1,28 @@
+//
+//  LocationReducer.swift
+//  MapFeature
+//
+//  Created by Jiyeon on 4/7/25.
+//  Copyright © 2025 com.pida.me.ios. All rights reserved.
+//
+
+import Foundation
+import FlowerSpotDomainInterface
+
+extension MapReducer {
+  
+  public enum LocationAction: Equatable {
+    case fetchUserLocation
+    case moveUserLocation
+    case saveUserLocation(MapPoint)
+    case moveLocation(MapPoint)
+    case requestMapBounds(Bool)
+    
+    case fetchFlowers([MapPoint])
+    case storeFlowerData([FlowerSpot])
+    
+    case mapSearchError(String?)
+    case showToastView(message: String?)
+  }
+  
+}

--- a/Projects/Features/Map/MapFeatureInterface/Sources/MapView/MapReducer.swift
+++ b/Projects/Features/Map/MapFeatureInterface/Sources/MapView/MapReducer.swift
@@ -48,11 +48,6 @@ public struct MapReducer {
     public var requestMapBound: Bool = false
     /// 현위치 재검색 버튼 활성화 여부
     public var researchButtonEnable: Bool = false
-    /// 현재 위치에서 특정 지점까지의 거리 (단위: 킬로미터)
-    public var distance: Double = .zero
-    /// DetailView가 fetch가 필요한 지 여부 flag
-    public var isNeedFetchDetail: Bool = false
-    
     /// 검색 결과 데이터
     public var searchResult: FlowerSpot? = nil
     /// 검색 결과 텍스트
@@ -60,22 +55,9 @@ public struct MapReducer {
     
     public var toastMessage: String? = nil
     
-    public var selectedItem: FlowerSpot? = nil
-    /// 네트워크로 받아온 상세 데이터
-    public var selectedItemDetail: FlowerSpot? = nil
-    /// 네트워크로 받아온 개화 상태 데이터
-    public var selectedItemBlooming: BloomStatusEntity? = nil
-    /// 네트워크로 받아온 투표 상태 데이터
-    public var selectedItemVote: VerifyBloomingStateEntity? = nil
-    /// 로딩 여부
-    public var isDetailLoading: Bool = false
-    
     public var isViewAppeared: Bool = false
-    /// 바텀시트 띄우기 트리거
-    public var isBottomSheetPresented: Bool = false
     
-    public var updateMarkerStatus: BloomStatus? = nil
-    
+    public var detail: DetailState = .init()
     public init() {}
   }
   
@@ -90,59 +72,19 @@ public struct MapReducer {
     
     case markerTapped(id: Int?)
     case fetchPathLines(Int)
-    case fetchFlowers([MapPoint])
-    case storeFlowerData([FlowerSpot])
     
-    case mapSearchError(String?)
     case fetchDetailInfo(Int)
-    
-    // MARK: - Search
     
     case showSearchResult(FlowerSpot?)
     case setSearchBarText(String?)
     case resetSearchBar
-    
-    // MARK: - Delegate
     
     case delegate(Delegate)
     case presentToSearch
     case pushToSetting
   }
   
-  // MARK: - Location Action
-  
-  public enum LocationAction: Equatable {
-    case fetchUserLocation
-    case moveUserLocation
-    case saveUserLocation(MapPoint)
-    case moveLocation(MapPoint)
-    case requestMapBounds(Bool)
-  }
-  
-  // MARK: - Detail Action
-  
-  public enum DetailAction: Equatable {
-    case fetchPathLines(Int)
-    case selectedItem(FlowerSpot)
-    
-    case requestDetailInfo(Int)
-    case fetchDetailInfo(Int)
-    
-    case detailResponse(FlowerSpot)
-    case bloomingResponse(BloomStatusEntity)
-    case verifyTodayBlooming(VerifyBloomingStateEntity)
-    case allDataUpdated
-    
-    case calculateDistance(MapPoint)
-    case updateMarkerStatus(BloomStatus, id: Int)
-    case dismissBottomSheet
-    case presentToDetail(
-      flowerSpotData: FlowerSpot,
-      bloomingStatus: BloomStatusEntity,
-      distance: Double,
-      isVotedBlooming: VerifyBloomingStateEntity
-    )
-  }
+  // MARK: - Delegate
   
   public enum Delegate: Equatable {
     case presentToSearch(String?)

--- a/Projects/Features/Map/MapFeatureInterface/Sources/MapView/MapReducer.swift
+++ b/Projects/Features/Map/MapFeatureInterface/Sources/MapView/MapReducer.swift
@@ -16,18 +16,18 @@ import DesignKit
 @Reducer
 public struct MapReducer {
   private let reducer: Reduce<State, Action>
-  
-  public init(reducer: Reduce<State, Action>) {
+  private let location: Reduce<LocationState, LocationAction>
+  public init(reducer: Reduce<State, Action>,
+              location: Reduce<LocationState, LocationAction>
+  ) {
     self.reducer = reducer
+    self.location = location
   }
   
   @ObservableState
   public struct State: Equatable {
     
-    /// 특정 지점으로 이동하기 위한 위치정보
-    public var point: MapPoint? = nil
-    /// 유저의 현재 위치
-    public var userLocation: MapPoint? = nil
+    public var location: LocationState = .init()
     /// 현재 지도에 보여 줄 FlowerSpot 데이터
     public var flowerSpots: [Int: FlowerSpot] = [:]
     /// 현재 그려져있는 경로
@@ -67,9 +67,10 @@ public struct MapReducer {
     public var isBottomSheetPresented: Bool = false
     
     public var updateMarkerStatus: BloomStatus? = nil
-
+    
     public init() {}
   }
+  
   
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
@@ -77,10 +78,7 @@ public struct MapReducer {
     
     // MARK: - Map
     
-    case fetchUserLocation
-    case moveUserLocation
-    case saveUserLocation(MapPoint)
-    case moveLocation(MapPoint)
+    case location(LocationAction)
     
     case fetchFlowers([MapPoint])
     case storeFlowerData([FlowerSpot])
@@ -126,6 +124,20 @@ public struct MapReducer {
     )
   }
   
+  public struct LocationState: Equatable {
+    /// 특정 지점으로 이동하기 위한 위치정보
+    public var point: MapPoint? = nil
+    /// 유저의 현재 위치
+    public var userLocation: MapPoint? = nil
+  }
+  
+  public enum LocationAction: Equatable {
+    case fetchUserLocation
+    case moveUserLocation
+    case saveUserLocation(MapPoint)
+    case moveLocation(MapPoint)
+  }
+  
   public enum Delegate: Equatable {
     case presentToSearch(String?)
     case pushToSetting
@@ -140,6 +152,10 @@ public struct MapReducer {
   
   public var body: some ReducerOf<Self> {
     BindingReducer()
+    Scope(state: \.location, action: \.location) {
+      location
+    }
     reducer
+    
   }
 }

--- a/Projects/Features/Map/MapFeatureInterface/Sources/MapView/MapReducer.swift
+++ b/Projects/Features/Map/MapFeatureInterface/Sources/MapView/MapReducer.swift
@@ -16,18 +16,26 @@ import DesignKit
 @Reducer
 public struct MapReducer {
   private let reducer: Reduce<State, Action>
-  private let location: Reduce<LocationState, LocationAction>
-  public init(reducer: Reduce<State, Action>,
-              location: Reduce<LocationState, LocationAction>
+  private let location: Reduce<State, LocationAction>
+  private let detail: Reduce<State, DetailAction>
+  
+  public init(
+    reducer: Reduce<State, Action>,
+    location: Reduce<State, LocationAction>,
+    detail: Reduce<State, DetailAction>
   ) {
     self.reducer = reducer
     self.location = location
+    self.detail = detail
   }
   
   @ObservableState
   public struct State: Equatable {
+    /// 특정 지점으로 이동하기 위한 위치정보
+    public var point: MapPoint? = nil
+    /// 유저의 현재 위치
+    public var userLocation: MapPoint? = nil
     
-    public var location: LocationState = .init()
     /// 현재 지도에 보여 줄 FlowerSpot 데이터
     public var flowerSpots: [Int: FlowerSpot] = [:]
     /// 현재 그려져있는 경로
@@ -74,40 +82,23 @@ public struct MapReducer {
   
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
-    case showToastView(message: String?)
-    
-    // MARK: - Map
-    
     case location(LocationAction)
+    case detail(DetailAction)
     
-    case fetchFlowers([MapPoint])
-    case storeFlowerData([FlowerSpot])
-    case fetchPathLines(Int)
+    case showToastView(message: String?)
+    case viewDidAppear
     
     case markerTapped(id: Int?)
-    case detailResponse(FlowerSpot)
-    case bloomingResponse(BloomStatusEntity)
-    case verifyTodayBlooming(VerifyBloomingStateEntity)
-    case allDataUpdated
-    case updateMarkerStatus(BloomStatus, id: Int)
+    case fetchPathLines(Int)
+    case fetchFlowers([MapPoint])
+    case storeFlowerData([FlowerSpot])
     
-    case requestMapBounds(Bool)
     case mapSearchError(String?)
-    
-    case selectedItem(FlowerSpot)
-    case dismissBottomSheet
-    case requestDetailInfo(Int)
     case fetchDetailInfo(Int)
-    
-    
-    case calculateDistance(MapPoint)
-    
-    // MARK: - Life Cycle
-    case viewDidAppear
     
     // MARK: - Search
     
-    case showSearchResult(FlowerSpot?) // TODO: - ItemType
+    case showSearchResult(FlowerSpot?)
     case setSearchBarText(String?)
     case resetSearchBar
     
@@ -116,26 +107,41 @@ public struct MapReducer {
     case delegate(Delegate)
     case presentToSearch
     case pushToSetting
-    case presentToDetail(
-      flowerSpotData: FlowerSpot,
-      bloomingStatus: BloomStatusEntity,
-      distance: Double,
-      isVotedBlooming: VerifyBloomingStateEntity
-    )
   }
   
-  public struct LocationState: Equatable {
-    /// 특정 지점으로 이동하기 위한 위치정보
-    public var point: MapPoint? = nil
-    /// 유저의 현재 위치
-    public var userLocation: MapPoint? = nil
-  }
+  // MARK: - Location Action
   
   public enum LocationAction: Equatable {
     case fetchUserLocation
     case moveUserLocation
     case saveUserLocation(MapPoint)
     case moveLocation(MapPoint)
+    case requestMapBounds(Bool)
+  }
+  
+  // MARK: - Detail Action
+  
+  public enum DetailAction: Equatable {
+    case fetchPathLines(Int)
+    case selectedItem(FlowerSpot)
+    
+    case requestDetailInfo(Int)
+    case fetchDetailInfo(Int)
+    
+    case detailResponse(FlowerSpot)
+    case bloomingResponse(BloomStatusEntity)
+    case verifyTodayBlooming(VerifyBloomingStateEntity)
+    case allDataUpdated
+    
+    case calculateDistance(MapPoint)
+    case updateMarkerStatus(BloomStatus, id: Int)
+    case dismissBottomSheet
+    case presentToDetail(
+      flowerSpotData: FlowerSpot,
+      bloomingStatus: BloomStatusEntity,
+      distance: Double,
+      isVotedBlooming: VerifyBloomingStateEntity
+    )
   }
   
   public enum Delegate: Equatable {
@@ -152,8 +158,11 @@ public struct MapReducer {
   
   public var body: some ReducerOf<Self> {
     BindingReducer()
-    Scope(state: \.location, action: \.location) {
+    Scope(state: \.self, action: \.location) {
       location
+    }
+    Scope(state: \.self, action: \.detail) {
+      detail
     }
     reducer
     

--- a/Projects/Features/Map/MapFeatureInterface/Sources/MapView/MapView.swift
+++ b/Projects/Features/Map/MapFeatureInterface/Sources/MapView/MapView.swift
@@ -33,7 +33,7 @@ public struct MapView: View {
         if store.researchButtonEnable {
           ResearchButton(
             action: {
-              store.send(.requestMapBounds(true))
+              store.send(.location(.requestMapBounds(true)))
             }
           )
         }
@@ -79,7 +79,7 @@ extension MapView {
   @ViewBuilder
   private var mapView: some View {
     MapViewRepresentable(
-      userLocation: $store.location.point,
+      userLocation: $store.point,
       flowerPositions: $store.state.flowerSpots,
       newPath: $store.state.selectedPathLines,
       requestBounds: $store.requestMapBound,
@@ -97,7 +97,7 @@ extension MapView {
     .onMarkerTapped { id in
       store.send(.markerTapped(id: id))
       if id == .none {
-        store.send(.dismissBottomSheet)
+        store.send(.detail(.dismissBottomSheet))
       }
     }
     .ignoresSafeArea()
@@ -105,7 +105,6 @@ extension MapView {
   
   @ViewBuilder
   private func searchView() -> some View {
-    // TODO: - ontap 시 textfield에 텍스트
     if let result = store.searchText { // 검색 결과
       SearchBar(
         text: .constant(result),
@@ -116,7 +115,7 @@ extension MapView {
             .size(.extraLarge)
             .action {
               store.send(.resetSearchBar)
-              store.send(.dismissBottomSheet)
+              store.send(.detail(.dismissBottomSheet))
               store.send(.markerTapped(id: nil))
             }
         }
@@ -156,12 +155,12 @@ extension MapView {
              let bloomingStatus = bloomingStatus,
              let isVotedBlooming = isVotedBlooming {
             store.send(
-              .presentToDetail(
+              .detail(.presentToDetail(
                 flowerSpotData: item,
                 bloomingStatus: bloomingStatus,
                 distance: store.distance,
                 isVotedBlooming: isVotedBlooming
-              )
+              ))
             )
           }
         }
@@ -169,7 +168,7 @@ extension MapView {
       onPullDown:  {
         return await MainActor.run {
           store.send(.resetSearchBar)
-          store.send(.dismissBottomSheet)
+          store.send(.detail(.dismissBottomSheet))
           store.send(.markerTapped(id: nil))
         }
       },
@@ -179,12 +178,12 @@ extension MapView {
              let bloomingStatus = bloomingStatus,
              let isVotedBlooming = isVotedBlooming {
             store.send(
-              .presentToDetail(
+              .detail(.presentToDetail(
                 flowerSpotData: item,
                 bloomingStatus: bloomingStatus,
                 distance: store.distance,
                 isVotedBlooming: isVotedBlooming
-              )
+              ))
             )
           }
         }

--- a/Projects/Features/Map/MapFeatureInterface/Sources/MapView/MapView.swift
+++ b/Projects/Features/Map/MapFeatureInterface/Sources/MapView/MapView.swift
@@ -57,14 +57,14 @@ public struct MapView: View {
     .ignoresSafeArea(edges: .bottom)
     .onAppear {
       if !store.isViewAppeared {
-        store.send(.fetchUserLocation)
+        store.send(.location(.fetchUserLocation))
         store.send(.viewDidAppear)
       }
       
     }
     .task {
       for await _ in LocationService.shared.userLocationStream {
-        store.send(.moveUserLocation)
+        store.send(.location(.moveUserLocation))
       }
     }
   }
@@ -79,7 +79,7 @@ extension MapView {
   @ViewBuilder
   private var mapView: some View {
     MapViewRepresentable(
-      userLocation: $store.state.point,
+      userLocation: $store.location.point,
       flowerPositions: $store.state.flowerSpots,
       newPath: $store.state.selectedPathLines,
       requestBounds: $store.requestMapBound,
@@ -214,7 +214,7 @@ extension MapView {
           .size(.superLarge)
       }
       .action {
-        store.send(.fetchUserLocation)
+        store.send(.location(.fetchUserLocation))
       }
       .elevation(cornerRadius: .Number24)
     }

--- a/Projects/Features/Map/MapFeatureInterface/Sources/MapView/MapView.swift
+++ b/Projects/Features/Map/MapFeatureInterface/Sources/MapView/MapView.swift
@@ -45,10 +45,10 @@ public struct MapView: View {
     }
     .overlay(
         Group {
-          if store.isBottomSheetPresented {
-            let item = store.selectedItemDetail
-            let bloomingStatus = store.selectedItemBlooming
-            let isVotedBlooming = store.selectedItemVote
+          if store.detail.isBottomSheetPresented {
+            let item = store.detail.selectedItemDetail
+            let bloomingStatus = store.detail.selectedItemBlooming
+            let isVotedBlooming = store.detail.selectedItemVote
             BottomSheet(item: item, bloomingStatus: bloomingStatus, isVotedBlooming: isVotedBlooming)
           }
         },
@@ -87,11 +87,11 @@ extension MapView {
       focusData: $store.searchResult,
       isNeedDeleteMarker: $store.isNeedDeleteMarker,
       isNeedDrawMarker: $store.isNeedDrawMarker,
-      updateMarkerStatus: $store.updateMarkerStatus
+      updateMarkerStatus: $store.detail.updateMarkerStatus
     )
     .onReceiveMapBounds {
       if store.requestMapBound {
-        store.send(.fetchFlowers($0))
+        store.send(.location(.fetchFlowers($0)))
       }
     }
     .onMarkerTapped { id in
@@ -146,9 +146,9 @@ extension MapView {
     CherryBlossomBottomSheet(
       title: item?.streetName,
       description: item?.address,
-      tags: [item?.district, "\(store.distance) km", item?.recentlyVisitedCountString],
+      tags: [item?.district, "\(store.detail.distance) km", item?.recentlyVisitedCountString],
       blossomState: item?.bloomingStatus,
-      isLoading: store.isDetailLoading,
+      isLoading: store.detail.isDetailLoading,
       onPullUp: {
         return await MainActor.run {
           if let item = item,
@@ -158,7 +158,7 @@ extension MapView {
               .detail(.presentToDetail(
                 flowerSpotData: item,
                 bloomingStatus: bloomingStatus,
-                distance: store.distance,
+                distance: store.detail.distance,
                 isVotedBlooming: isVotedBlooming
               ))
             )
@@ -181,7 +181,7 @@ extension MapView {
               .detail(.presentToDetail(
                 flowerSpotData: item,
                 bloomingStatus: bloomingStatus,
-                distance: store.distance,
+                distance: store.detail.distance,
                 isVotedBlooming: isVotedBlooming
               ))
             )
@@ -218,6 +218,6 @@ extension MapView {
       .elevation(cornerRadius: .Number24)
     }
     .padding(.trailing, .Number16)
-    .padding(.bottom, store.selectedItemDetail != nil ? 180 : 40)
+    .padding(.bottom, store.detail.selectedItemDetail != nil ? 180 : 40)
   }
 }


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #

## 🔎 작업 내용
- MapReducer 내부에서 관심사 별 reducer 분리

## 📷 스크린샷

## 🛠️ 기타 공유 내용
일단은 `MapReducer`에 많은 내용이 한 번에 담겨있어 가독성이 떨어진다는 문제가 있습니다. 그렇다고 완전히 분리하기엔 지도라는 틀 내에서 모두 돌아가고 있기 때문에 적절하지 않다고 생각했습니다.

`MapReducer`내에서 위치 관련, 지도 관련, 디테일 관련 코드들이 들어있기 때문에 하위 리듀서로 위치, 디테일을 분리했습니다.
`LocationReducer`는 지도에서 현재 위치 및 지도 위치에 맞는 정보 불러오기, `DetailReducer`는 특정 위치에 대한 상세 정보 및 관련 데이터 불러오는 액션으로 분리했습니다.

여러 곳에서 공통으로 사용하는 `markerTapped`, `fetchPathLines` 등은 그래도 `MapReducer`의 `Action`에 두었고, `Search`관련 액션은 디테일, 위치 쪽과 모두 상호작용이 있기 때문에 상위 리듀서인 `MapReducer`에 두었습니다!
