### PR TITLE
SettingView QA 사항 적용

### DIFF
--- a/Projects/Core/Networker/Sources/Implement/Networker.swift
+++ b/Projects/Core/Networker/Sources/Implement/Networker.swift
@@ -44,7 +44,14 @@ public struct Networker: NetworkProtocol, Sendable {
             endpoint: endpoint
           )
         }
-      } catch {
+      } catch let error as NetworkError {
+        group.cancelAll()
+        throw error
+      } catch let error as FoundationError {
+        group.cancelAll()
+        throw error
+      }
+      catch {
         group.cancelAll()
         throw throwError(
           FoundationError.taskCancelled,

--- a/Projects/Core/Networker/Sources/Implement/Networker.swift
+++ b/Projects/Core/Networker/Sources/Implement/Networker.swift
@@ -128,8 +128,9 @@ extension Networker {
       case 400...599:
         throw throwError(
           NetworkError.serverError(
-            message: errorResponse.message,
-            code: httpResponse.statusCode
+            message: errorResponse.data.message,
+            code: errorResponse.status,
+            className: errorResponse.data.errorClassName
           ),
           endpoint: endpoint
         )

--- a/Projects/Core/Networker/Sources/Interface/ErrorResponse.swift
+++ b/Projects/Core/Networker/Sources/Interface/ErrorResponse.swift
@@ -9,6 +9,13 @@
 import Foundation
 
 public struct ErrorResponse: Decodable, Sendable {
-  public let code: String
+  public let success: Bool
+  public let status: Int
+  public let data: ErrorData
+  public let timestamp: String
+}
+
+public struct ErrorData: Decodable, Sendable {
+  public let errorClassName: String
   public let message: String
 }

--- a/Projects/Features/Auth/AuthFeature/Sources/SignUpReducer.swift
+++ b/Projects/Features/Auth/AuthFeature/Sources/SignUpReducer.swift
@@ -26,52 +26,73 @@ extension SignUpReducer {
       case .onAppear:
         return .run { send in
           await MainActor.run {
-            send(.initState)
             send(.showKeyboard(true))
+            send(.initState)
           }
         }
+      case let .showToastView(message):
+        state.toastMessage = message
+        return .none
+        
       case let .showKeyboard(isShow):
         state.focusKeyboard = isShow
         return .none
         
       case .initState:
-        state.nickname = ""
         state.isValidInput = true
         state.inputValid = .none
         state.isLoading = false
         
         return .none
+        
+      case let .isLoading(isLoading):
+        state.isLoading = isLoading
+        return .none
+        
       case .confirmTapped:
         return .send(.requestSignUp(nickname: state.nickname))
           .throttle(id: ID.throttle, for: 0.3, scheduler: mainQueue, latest: false)
         
       case let .checkValidNickName(nickname):
+        let inputValid: NickNameInputValid
         if nickname.count < 2 {
-          state.inputValid = .tooShort
+          inputValid = .tooShort
         } else if nickname.count > 12 {
-          state.inputValid = .tooLong
+          inputValid = .tooLong
         } else {
-          state.inputValid = .valid
+          inputValid = .valid
         }
+        return .send(.nicknameValidMessage(inputValid))
+        
+      case let .nicknameValidMessage(type):
+        state.inputValid = type
         state.isValidInput = state.inputValid.isValid
         return .none
         
       case let .requestSignUp(nickname):
-        state.isLoading = true
         return .run { send in
+          await send(.isLoading(true))
           do {
             if let email: String = KeyChainWrapper.read(forKey: .email) {
               try await signUpUseCase.execute(email: email, nickname: nickname)
               UserDefault.isLoggedIn = true
               await send(.fetchUserInfo)
             }
-          } catch {
-            print(error.localizedDescription)
+          } catch let error as NetworkError {
+            if error.errorClassName == .duplicateNickname {
+              await send(.nicknameValidMessage(.duplicate))
+              await send(.isLoading(false))
+              
+            } else {
+              await send(.isLoading(false))
+              await send(.showToastView(message: "회원가입에 실패했어요."))
+            }
+          }
+          catch {
+            await send(.isLoading(false))
+            await send(.showToastView(message: "회원가입에 실패했어요."))
           }
         }
-      case .failSignUp:
-        state.isLoading = false
-        return .none
         
       case .fetchUserInfo:
         return .run { send in

--- a/Projects/Features/Auth/AuthFeatureInterface/Sources/SignUp/SignUpReducer.swift
+++ b/Projects/Features/Auth/AuthFeatureInterface/Sources/SignUp/SignUpReducer.swift
@@ -25,18 +25,23 @@ public struct SignUpReducer {
     public var isValidInput: Bool = true
     public var inputValid: NickNameInputValid = .none
     public var isLoading: Bool = false
+    public var toastMessage: String? = nil
     public init() {}
   }
   
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
     case onAppear
+    case showToastView(message: String?)
+    
     case initState
+    case isLoading(Bool)
     case showKeyboard(Bool)
     case confirmTapped
     case checkValidNickName(String)
+    case nicknameValidMessage(NickNameInputValid)
+    
     case requestSignUp(nickname: String)
-    case failSignUp
     case fetchUserInfo
     
     case dismiss

--- a/Projects/Features/Auth/AuthFeatureInterface/Sources/SignUp/SignUpView.swift
+++ b/Projects/Features/Auth/AuthFeatureInterface/Sources/SignUp/SignUpView.swift
@@ -31,7 +31,7 @@ public struct SignUpView: View {
         nicknameTextField
         
         Spacer()
-        
+        ToastView(message: $store.toastMessage)
         completeButton
       }
       .padding(.horizontal, .Number16)
@@ -67,8 +67,8 @@ public struct SignUpView: View {
         store.send(.confirmTapped)
       }
       .isActive(store.inputValid.isValid)
-      .padding(.vertical, .Number16)
       .disabled(store.isLoading)
+      .padding(.vertical, .Number16)
   }
   
 }

--- a/Projects/Features/Setting/SettingFeature/Sources/ProfileUpdateReducer.swift
+++ b/Projects/Features/Setting/SettingFeature/Sources/ProfileUpdateReducer.swift
@@ -50,13 +50,18 @@ extension ProfileUpdateReducer {
           state.isValidInput = true
           return .none
         }
+        let inputValid: NickNameInputValid
         if nickname.count < 2 {
-          state.inputValid = .tooShort
+          inputValid = .tooShort
         } else if nickname.count > 12 {
-          state.inputValid = .tooLong
+          inputValid = .tooLong
         } else {
-          state.inputValid = .valid
+          inputValid = .valid
         }
+        return .send(.nicknameValidMessage(inputValid))
+        
+      case let .nicknameValidMessage(type):
+        state.inputValid = type
         state.isValidInput = state.inputValid.isValid
         return .none
         
@@ -67,7 +72,16 @@ extension ProfileUpdateReducer {
             let result = try await changeNicknameUseCase.execute(nickname: nickname)
             UserDefault.username = result.nickname
             await send(.pop)
-          } catch {
+          } catch let error as NetworkError {
+            if error.errorClassName == .duplicateNickname {
+              await send(.isLoading(false))
+              await send(.nicknameValidMessage(.duplicate))
+            } else {
+              await send(.isLoading(false))
+              await send(.showToastView(message: "닉네임 변경에 실패했어요."))
+            }
+          }
+          catch {
             await send(.isLoading(false))
             await send(.showToastView(message: "닉네임 변경에 실패했어요."))
           }

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingView.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/SettingView.swift
@@ -86,7 +86,12 @@ extension SettingView {
         Image(asset: ImageSet.avatarLarge.swiftUIImage)
         HStack(spacing: .Number0) {
           if store.isLoggedIn {
-            Text("환영해요! \(store.username)님")
+            HStack(spacing: .Number0) {
+              Text("환영해요! ")
+              Text(store.username)
+                .fontStyle(FontSet.Title.title3)
+              Text("님")
+            }
           } else {
             Text("로그인 하기")
           }
@@ -104,6 +109,12 @@ extension SettingView {
       BorderView(size: .short)
     }
     .padding(.horizontal, .Number16)
+  }
+  
+  @ViewBuilder
+  private var nicknameText: some View {
+    Text(store.username)
+      .fontStyle(FontSet.Title.title3)
   }
   
   private func alertView(type: AlertType) -> some View {

--- a/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateReducer.swift
+++ b/Projects/Features/Setting/SettingFeatureInterface/Sources/Update/ProfileUpdateReducer.swift
@@ -40,6 +40,7 @@ public struct ProfileUpdateReducer {
     case checkValidNickName(String)
     case showKeyboard(Bool)
     case changeNickName(String)
+    case nicknameValidMessage(NickNameInputValid)
     
     case delegate(Delegate)
     case pop

--- a/Projects/Shared/Utility/Sources/Errors/ErrorClassName.swift
+++ b/Projects/Shared/Utility/Sources/Errors/ErrorClassName.swift
@@ -1,0 +1,13 @@
+//
+//  ErrorClassName.swift
+//  Utility
+//
+//  Created by Jiyeon on 4/12/25.
+//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public enum ErrorClassName: String {
+  case duplicateNickname = "DUPLICATE_NICKNAME"
+}

--- a/Projects/Shared/Utility/Sources/Errors/NetworkError.swift
+++ b/Projects/Shared/Utility/Sources/Errors/NetworkError.swift
@@ -16,7 +16,8 @@ public enum NetworkError: Error, LocalizedError, Sendable {
   
   public var errorDescription: String {
     switch self {
-    case let .serverError(message, code, _): return "[에러코드: \(code)] - \(message)"
+    case let .serverError(message, code, className):
+      return "[에러코드: \(code)] - \(className)_\(message)"
     case let .invalidStatusCode(code): return "[잘못 된 StatusCode] - \(code)"
     case let .timeout(time): return "[네트워크 요청 시간이 초과되었습니다.] - \(time)Seconds"
     }

--- a/Projects/Shared/Utility/Sources/Errors/NetworkError.swift
+++ b/Projects/Shared/Utility/Sources/Errors/NetworkError.swift
@@ -12,13 +12,21 @@ public enum NetworkError: Error, LocalizedError, Sendable {
   
   case invalidStatusCode(Int)
   case timeout(TimeInterval)
-  case serverError(message: String, code: Int)
+  case serverError(message: String, code: Int, className: String)
   
   public var errorDescription: String {
     switch self {
-    case let .serverError(message, code): return "[에러코드: \(code)] - \(message)"
+    case let .serverError(message, code, _): return "[에러코드: \(code)] - \(message)"
     case let .invalidStatusCode(code): return "[잘못 된 StatusCode] - \(code)"
     case let .timeout(time): return "[네트워크 요청 시간이 초과되었습니다.] - \(time)Seconds"
+    }
+  }
+  
+  public var errorClassName: ErrorClassName? {
+    switch self {
+    case let .serverError(_, _, className):
+      return ErrorClassName(rawValue: className)
+    default: return nil
     }
   }
 }

--- a/Projects/Shared/Utility/Sources/Types/ExternalURL.swift
+++ b/Projects/Shared/Utility/Sources/Types/ExternalURL.swift
@@ -12,7 +12,7 @@ public enum ExternalURL {
   public static let serviceTerm: URL? = URL(string: "https://wealthy-session-98c.notion.site/1c790c66759880cf905fef813ccd60d6?pvs=4")
   public static let privacyTerm: URL? = URL(string: "https://wealthy-session-98c.notion.site/1c790c667598807fbf33c207ef06c982?pvs=4")
   
-  public static let feedBack: URL? = URL(string: "https://docs.google.com/forms/d/e/1FAIpQLSdXZDODUO-SehJ5zM8DTQADC_2PXDclRw7KK0638Tyml2OSbA/viewform")
+  public static let feedBack: URL? = URL(string: "https://walla.my/survey/AJeO2hbuPsrsdOgel8zZ")
   
   public static let appStore: URL? = URL(string: "itms-apps://itunes.apple.com/app/id6744023330")
   

--- a/Projects/Shared/Utility/Sources/Types/NicknameValidType.swift
+++ b/Projects/Shared/Utility/Sources/Types/NicknameValidType.swift
@@ -12,6 +12,7 @@ public enum NickNameInputValid: Equatable {
   case tooShort
   case tooLong
   case none
+  case duplicate
 
   public var text: String? {
     switch self {
@@ -19,6 +20,7 @@ public enum NickNameInputValid: Equatable {
     case .tooShort: return "닉네임은 2자 이상 입력해주세요."
     case .tooLong: return "닉네임은 12자 이하로 입력해주세요."
     case .none: return "2~12자까지 입력할 수 있어요."
+    case .duplicate: return "이미 사용중인 닉네임이에요."
     }
   }
   


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #79 

## 🔎 작업 내용
- 닉네임 폰트 변경
- 피드백 남기기 링크 왈라 링크로 변경
- 닉네임 중복 시 텍스트필드 오류 메세지 추가
- ErrorResponse 수정
- 네트워크 요쳥 실패 시 반환되는 에러 타입 변경

## 📷 스크린샷
| 닉네임 폰트 변경 | 닉네임 중복 |
|:----:|:----:|
|<img src = "https://github.com/user-attachments/assets/89d1f682-d5b7-498f-a643-ce674955384a" width = "300">|<img src = "https://github.com/user-attachments/assets/07e0e716-8e25-4a89-83ee-78cb6b03c4eb" width = "300">|

## 🛠️ 기타 공유 내용
네트워크 에러 발생 시 task cancel을 하면서 throw되는 에러 타입이 이전에 발생한 Error타입에서 `FoundationError.taskCancelled` 에러로 변경되어 `reducer`에서 `taskCancelled`에러만 받게 되는 문제가 있었습니다.
그래서 에러가 발생하여 task를 cancel 할 때 받은 `error`의 타입 확인 후 특정한 에러 타입이 아니라면 `.taskCancelled`에러를 던지도록 수정했습니다!
```swift
// Networker.swift
...
do {
  ...
}
catch let error as NetworkError {
  group.cancelAll()
  throw error
} catch let error as FoundationError {
  group.cancelAll()
  throw error
}
catch {
  group.cancelAll()
  throw throwError(
    FoundationError.taskCancelled,
    endpoint: endpoint
  )
}
```
