### PR TITLE
refactor: #105 MapFeature 내 Search 관련 로직 분리

### DIFF
--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
@@ -72,12 +72,12 @@ extension MapFeature {
         // flowerSpotDetail State 설정 (userLocation 전달하여 distance 계산 가능하게)
         state.flowerSpotDetail = .init(userLocation: state.userLocation)
         
-        return .run { send in
-          await send(.mapSearch(.hideRegionList)) // 리전 검색 결과 리스트에서 마커 탭 시 바텀시트 정리
-          await send(.mapSearch(.showRegionList(data: nil)))
-          await send(.fetchPathLines(id))
-          await send(.flowerSpotDetail(.requestDetailInfo(id)))
-        }
+        return .concatenate(
+          .send(.mapSearch(.showRegionList(data: nil))),
+          .send(.mapSearch(.setNavigationFromRegionList)),
+          .send(.fetchPathLines(id)),
+          .send(.flowerSpotDetail(.requestDetailInfo(id)))
+        )
         
       case let .fetchPathLines(id):
         if let data = state.flowerSpots[id] {

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
@@ -126,7 +126,7 @@ extension MapFeature {
         case .resetMarkerTapped:
           return .send(.markerTapped(id: nil))
           
-        case .dismissFlowerSpotDetil:
+        case .dismissFlowerSpotDetail:
           state.flowerSpotDetail = nil
           return .none
         }

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
@@ -72,12 +72,9 @@ extension MapFeature {
         // flowerSpotDetail State 설정 (userLocation 전달하여 distance 계산 가능하게)
         state.flowerSpotDetail = .init(userLocation: state.userLocation)
         
-        if state.isShowRegionList { // 리전 검색 결과 리스트에서 마커 탭 시 바텀시트 정리
-          state.isShowRegionList = false
-          state.detailRoot = .region
-        }
         return .run { send in
-          await send(.showRegionList(data: nil))
+          await send(.mapSearch(.hideRegionList)) // 리전 검색 결과 리스트에서 마커 탭 시 바텀시트 정리
+          await send(.mapSearch(.showRegionList(data: nil)))
           await send(.fetchPathLines(id))
           await send(.flowerSpotDetail(.requestDetailInfo(id)))
         }
@@ -107,7 +104,6 @@ extension MapFeature {
         switch action {
         case let .showSearchResult(result):
           if result != nil {
-            state.detailRoot = .search
             // flowerSpotDetail State 설정 (userLocation 전달하여 distance 계산 가능하게)
             state.flowerSpotDetail = .init(userLocation: state.userLocation)
           } else {
@@ -117,57 +113,23 @@ extension MapFeature {
           
         case let .presentToSearch(keyword):
           return .send(.delegate(.presentToSearch(keyword)))
-        }
-        
-        // MARK: - Search
-        
-      case let .showRegionList(result):
-        state.isShowRegionList = result != nil
-        if let result = result {
-          state.regionResult = result
-          state.searchRegionList = .init(region: result)
-          return showSearchRegionResult(name: result.name, coord: result.coordinate)
-        } else {
-          state.regionSheetDetent = .medium
-          state.searchRegionList = nil
-          return .none
-        }
-        
-      case .changeRegionSheetDetent:
-        if state.isShowRegionList {
-          state.regionSheetDetent = .low
-        }
-        return .none
-        
-      case .searchBackButtonTapped:
-        return .concatenate(
-          .send(.handleSearchBackNavigation),
-          .send(.mapSearch(.resetSearchBar)),
-          .send(.markerTapped(id: nil))
-        )
-        
-      case .handleSearchBackNavigation:
-        switch state.detailRoot {
-        case .region:
+          
+        case let .showSearchRegionList(result):
+          if let result = result {
+            state.searchRegionList = .init(region: result)
+            return showSearchRegionResult(name: result.name, coord: result.coordinate)
+          } else {
+            state.searchRegionList = nil
+            return .none
+          }
+          
+        case .resetMarkerTapped:
+          return .send(.markerTapped(id: nil))
+          
+        case .dismissFlowerSpotDetil:
           state.flowerSpotDetail = nil
-          state.detailRoot = nil
-          if let result = state.regionResult {
-            return .send(.showRegionList(data: result))
-          }
           return .none
-        case .search:
-          state.detailRoot = nil
-          return .send(.mapSearch(.presentToSearch))
-        case nil:
-          if state.isShowRegionList {
-            state.regionResult = nil
-            return .concatenate(
-              .send(.showRegionList(data: nil)),
-              .send(.mapSearch(.presentToSearch))
-            )
-          }
         }
-        return .none
         
         // MARK: - Alert
         
@@ -245,9 +207,9 @@ extension MapFeature {
       case let .searchRegionList(.delegate(action)):
         switch action {
         case let .showFlowerSpotDetail(data):
-          state.detailRoot = .region
+          state.mapSearch.detailRoot = .region
           return .concatenate(
-            .send(.showRegionList(data: nil)),
+            .send(.mapSearch(.showRegionList(data: nil))),
             .send(.fetchDetailInfo(data.id)),
             .send(.location(.moveLocation(data.pinPoint)))
           )

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
@@ -200,16 +200,16 @@ extension MapFeature {
           return .send(.delegate(.presentToLogin(id: id)))
 
         case let .showOnMap(flowerSpot):
-          state.mapSearch.searchResult = flowerSpot // TODO: - 왜 저장하는지?
+          state.mapSearch.searchResult = flowerSpot 
           return .send(.location(.moveLocation(flowerSpot.pinPoint)))
         }
         
       case let .searchRegionList(.delegate(action)):
         switch action {
         case let .showFlowerSpotDetail(data):
-          state.mapSearch.detailRoot = .region
           return .concatenate(
             .send(.mapSearch(.showRegionList(data: nil))),
+            .send(.mapSearch(.setNavigationFromRegionList)),
             .send(.fetchDetailInfo(data.id)),
             .send(.location(.moveLocation(data.pinPoint)))
           )

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
@@ -18,12 +18,14 @@ import SearchRegionListFeatureInterface
 extension MapFeature {
   public init(
     location: Reduce<LocationFeature.State, LocationFeature.Action>,
+    mapSearch: Reduce<MapSearchFeature.State, MapSearchFeature.Action>,
     flowerSpotDetail: FlowerSpotDetailFeature,
     searchRegionList: SearchRegionListFeature
   ) {
     self.init(
       reducer: Reduce(Core()),
       location: location,
+      mapSearch: mapSearch,
       flowerSpotDetail: flowerSpotDetail,
       searchRegionList: searchRegionList
     )
@@ -100,6 +102,11 @@ extension MapFeature {
         )
         
         // MARK: - Search
+        
+      case let .mapSearch(.delegate(action)):
+        switch action {
+        default: return .none
+        }
         
       case let .showSearchResult(result):
         state.searchResult = result
@@ -260,7 +267,7 @@ extension MapFeature {
       case .flowerSpotDetail:
         return .none
         
-      case .binding, .delegate, .alertAcceptTapped, .location, .searchRegionList:
+      case .binding, .delegate, .alertAcceptTapped, .location, .searchRegionList, .mapSearch:
         return .none
         
       }

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
@@ -101,33 +101,25 @@ extension MapFeature {
           .send(.flowerSpotDetail(.fetchDetailInfo(id)))
         )
         
-        // MARK: - Search
+        // MARK: - MapSearch Delegate Action
         
       case let .mapSearch(.delegate(action)):
         switch action {
-        default: return .none
+        case let .showSearchResult(result):
+          if result != nil {
+            state.detailRoot = .search
+            // flowerSpotDetail State 설정 (userLocation 전달하여 distance 계산 가능하게)
+            state.flowerSpotDetail = .init(userLocation: state.userLocation)
+          } else {
+            state.flowerSpotDetail = nil
+          }
+          return showSearchResult(result: result)
+          
+        case let .presentToSearch(keyword):
+          return .send(.delegate(.presentToSearch(keyword)))
         }
         
-      case let .showSearchResult(result):
-        state.searchResult = result
-        if result != nil {
-          state.detailRoot = .search
-          // flowerSpotDetail State 설정 (userLocation 전달하여 distance 계산 가능하게)
-          state.flowerSpotDetail = .init(userLocation: state.userLocation)
-        } else {
-          state.flowerSpotDetail = nil
-        }
-        return showSearchResult(result: result)
-        
-      case let .setSearchBarText(text):
-        state.searchText = text
-        return .none
-        
-      case .resetSearchBar:
-        return .concatenate(
-          .send(.showSearchResult(nil)),
-          .send(.setSearchBarText(nil))
-        )
+        // MARK: - Search
         
       case let .showRegionList(result):
         state.isShowRegionList = result != nil
@@ -150,7 +142,7 @@ extension MapFeature {
       case .searchBackButtonTapped:
         return .concatenate(
           .send(.handleSearchBackNavigation),
-          .send(.resetSearchBar),
+          .send(.mapSearch(.resetSearchBar)),
           .send(.markerTapped(id: nil))
         )
         
@@ -165,13 +157,13 @@ extension MapFeature {
           return .none
         case .search:
           state.detailRoot = nil
-          return .send(.presentToSearch)
+          return .send(.mapSearch(.presentToSearch))
         case nil:
           if state.isShowRegionList {
             state.regionResult = nil
             return .concatenate(
               .send(.showRegionList(data: nil)),
-              .send(.presentToSearch)
+              .send(.mapSearch(.presentToSearch))
             )
           }
         }
@@ -227,9 +219,6 @@ extension MapFeature {
         
         // MARK: - Delegate
 
-      case .presentToSearch:
-        return .send(.delegate(.presentToSearch(state.searchText)))
-
       case .pushToSetting:
         return .send(.delegate(.pushToSetting))
 
@@ -249,7 +238,7 @@ extension MapFeature {
           return .send(.delegate(.presentToLogin(id: id)))
 
         case let .showOnMap(flowerSpot):
-          state.searchResult = flowerSpot
+          state.mapSearch.searchResult = flowerSpot // TODO: - 왜 저장하는지?
           return .send(.location(.moveLocation(flowerSpot.pinPoint)))
         }
         
@@ -295,7 +284,7 @@ extension MapFeature.Core {
   private func showSearchResult(result: FlowerSpotEntity?) -> Effect<Action> {
     return .run { send in
       if let result = result {
-        await send(.setSearchBarText(result.streetName))
+        await send(.mapSearch(.setSearchBarText(result.streetName)))
         await send(.location(.moveLocation(result.pinPoint)))
         await send(.fetchPathLines(result.id))
         await send(.flowerSpotDetail(.requestDetailInfo(result.id)))
@@ -305,7 +294,7 @@ extension MapFeature.Core {
   
   private func showSearchRegionResult(name: String, coord: Coordinate) -> Effect<Action> {
     return .run { send in
-      await send(.setSearchBarText(name))
+      await send(.mapSearch(.setSearchBarText(name)))
       await send(.location(.moveLocation(coord)))
       await send(.location(.fetchFlowersInRadius(coordinate: coord, radiusInKm: 1.0)))
     }

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
@@ -256,6 +256,7 @@ extension MapFeature.Core {
   
   private func showSearchRegionResult(name: String, coord: Coordinate) -> Effect<Action> {
     return .run { send in
+      await send(.markerTapped(id: nil))
       await send(.mapSearch(.setSearchBarText(name)))
       await send(.location(.moveLocation(coord)))
       await send(.location(.fetchFlowersInRadius(coordinate: coord, radiusInKm: 1.0)))

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/SubFeature/MapSearchFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/SubFeature/MapSearchFeature.swift
@@ -21,10 +21,6 @@ extension MapSearchFeature {
     public func reduce(into state: inout State, action: Action) -> Effect<Action> {
       switch action {
         
-      case let .showSearchResult(result):
-        state.searchResult = result
-        return .send(.delegate(.showSearchResult(result)))
-        
       case let .setSearchBarText(text):
         state.searchText = text
         return .none
@@ -35,9 +31,66 @@ extension MapSearchFeature {
           .send(.setSearchBarText(nil))
         )
         
+      case let .showSearchResult(result):
+        state.searchResult = result
+        if result != nil {
+          state.detailRoot = .search
+        }
+        return .send(.delegate(.showSearchResult(result)))
+        
       case .presentToSearch:
         return .send(.delegate(.presentToSearch(state.searchText)))
         
+      case let .showRegionList(result):
+        state.isShowRegionList = result != nil
+        if let result = result {
+          state.regionResult = result
+        } else {
+          state.regionSheetDetent = .medium
+        }
+        return .send(.delegate(.showSearchRegionList(result)))
+        
+      case .hideRegionList:
+        if state.isShowRegionList { // 리전 검색 결과 리스트에서 마커 탭 시 바텀시트 정리
+          state.isShowRegionList = false
+          state.detailRoot = .region
+        }
+        return .none
+        
+      case .changeRegionSheetDetent:
+        if state.isShowRegionList {
+          state.regionSheetDetent = .low
+        }
+        return .none
+        
+      case .searchBackButtonTapped:
+        return .concatenate(
+          .send(.handleSearchBackNavigation),
+          .send(.resetSearchBar),
+          .send(.delegate(.resetMarkerTapped))
+        )
+        
+      case .handleSearchBackNavigation:
+        switch state.detailRoot {
+        case .region:
+          state.detailRoot = nil
+          return .concatenate(
+            .send(.showRegionList(data: state.regionResult)),
+            .send(.delegate(.dismissFlowerSpotDetil))
+          )
+        case .search:
+          state.detailRoot = nil
+          return .send(.presentToSearch)
+        case nil:
+          if state.isShowRegionList {
+            state.regionResult = nil
+            return .concatenate(
+              .send(.showRegionList(data: nil)),
+              .send(.presentToSearch)
+            )
+          }
+        }
+        return .none
         
       case .binding, .delegate: return .none
       }

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/SubFeature/MapSearchFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/SubFeature/MapSearchFeature.swift
@@ -85,7 +85,7 @@ extension MapSearchFeature {
           state.currentNavigation = .regionList(region)
           return .concatenate(
             .send(.showRegionList(data: region)),
-            .send(.delegate(.dismissFlowerSpotDetil))
+            .send(.delegate(.dismissFlowerSpotDetail))
           )
           
         case .regionList:

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/SubFeature/MapSearchFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/SubFeature/MapSearchFeature.swift
@@ -33,8 +33,8 @@ extension MapSearchFeature {
         
       case let .showSearchResult(result):
         state.searchResult = result
-        if result != nil {
-          state.detailRoot = .search
+        if let result = result {
+          state.currentNavigation = .flowerDetail(.fromSearch(result))
         }
         return .send(.delegate(.showSearchResult(result)))
         
@@ -45,6 +45,7 @@ extension MapSearchFeature {
         state.isShowRegionList = result != nil
         if let result = result {
           state.regionResult = result
+          state.currentNavigation = .regionList(result)
         } else {
           state.regionSheetDetent = .medium
         }
@@ -53,7 +54,9 @@ extension MapSearchFeature {
       case .hideRegionList:
         if state.isShowRegionList { // 리전 검색 결과 리스트에서 마커 탭 시 바텀시트 정리
           state.isShowRegionList = false
-          state.detailRoot = .region
+          if case .regionList(let region) = state.currentNavigation {
+            state.currentNavigation = .flowerDetail(.fromRegionList(region))
+          }
         }
         return .none
         
@@ -71,24 +74,36 @@ extension MapSearchFeature {
         )
         
       case .handleSearchBackNavigation:
-        switch state.detailRoot {
-        case .region:
-          state.detailRoot = nil
+        switch state.currentNavigation {
+        case .flowerDetail(.fromSearch):
+          // 검색 → 상세 → 뒤로 = 검색화면
+          state.currentNavigation = .map
+          return .send(.presentToSearch)
+          
+        case .flowerDetail(.fromRegionList(let region)):
+          // 리전리스트 → 상세 → 뒤로 = 리전리스트 복원
+          state.currentNavigation = .regionList(region)
           return .concatenate(
-            .send(.showRegionList(data: state.regionResult)),
+            .send(.showRegionList(data: region)),
             .send(.delegate(.dismissFlowerSpotDetil))
           )
-        case .search:
-          state.detailRoot = nil
-          return .send(.presentToSearch)
-        case nil:
-          if state.isShowRegionList {
-            state.regionResult = nil
-            return .concatenate(
-              .send(.showRegionList(data: nil)),
-              .send(.presentToSearch)
-            )
-          }
+          
+        case .regionList:
+          // 리전리스트 → 뒤로 = 검색화면
+          state.currentNavigation = .map
+          state.regionResult = nil
+          return .concatenate(
+            .send(.showRegionList(data: nil)),
+            .send(.presentToSearch)
+          )
+          
+        case .map:
+          return .none
+        }
+        
+      case .setNavigationFromRegionList:
+        if let regionResult = state.regionResult {
+          state.currentNavigation = .flowerDetail(.fromRegionList(regionResult))
         }
         return .none
         

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/SubFeature/MapSearchFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/SubFeature/MapSearchFeature.swift
@@ -20,6 +20,25 @@ extension MapSearchFeature {
     
     public func reduce(into state: inout State, action: Action) -> Effect<Action> {
       switch action {
+        
+      case let .showSearchResult(result):
+        state.searchResult = result
+        return .send(.delegate(.showSearchResult(result)))
+        
+      case let .setSearchBarText(text):
+        state.searchText = text
+        return .none
+        
+      case .resetSearchBar:
+        return .concatenate(
+          .send(.showSearchResult(nil)),
+          .send(.setSearchBarText(nil))
+        )
+        
+      case .presentToSearch:
+        return .send(.delegate(.presentToSearch(state.searchText)))
+        
+        
       case .binding, .delegate: return .none
       }
     }

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/SubFeature/MapSearchFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/SubFeature/MapSearchFeature.swift
@@ -33,8 +33,8 @@ extension MapSearchFeature {
         
       case let .showSearchResult(result):
         state.searchResult = result
-        if let result = result {
-          state.currentNavigation = .flowerDetail(.fromSearch(result))
+        if let _ = result {
+          state.currentNavigation = .flowerDetail(.fromSearch)
         }
         return .send(.delegate(.showSearchResult(result)))
         
@@ -45,7 +45,7 @@ extension MapSearchFeature {
         state.isShowRegionList = result != nil
         if let result = result {
           state.regionResult = result
-          state.currentNavigation = .regionList(result)
+          state.currentNavigation = .regionList
         } else {
           state.regionSheetDetent = .medium
         }
@@ -54,9 +54,7 @@ extension MapSearchFeature {
       case .hideRegionList:
         if state.isShowRegionList { // 리전 검색 결과 리스트에서 마커 탭 시 바텀시트 정리
           state.isShowRegionList = false
-          if case .regionList(let region) = state.currentNavigation {
-            state.currentNavigation = .flowerDetail(.fromRegionList(region))
-          }
+          state.currentNavigation = .flowerDetail(.fromRegionList)
         }
         return .none
         
@@ -80,11 +78,11 @@ extension MapSearchFeature {
           state.currentNavigation = .map
           return .send(.presentToSearch)
           
-        case .flowerDetail(.fromRegionList(let region)):
+        case .flowerDetail(.fromRegionList):
           // 리전리스트 → 상세 → 뒤로 = 리전리스트 복원
-          state.currentNavigation = .regionList(region)
+          state.currentNavigation = .regionList
           return .concatenate(
-            .send(.showRegionList(data: region)),
+            .send(.showRegionList(data: state.regionResult)),
             .send(.delegate(.dismissFlowerSpotDetail))
           )
           
@@ -102,9 +100,7 @@ extension MapSearchFeature {
         }
         
       case .setNavigationFromRegionList:
-        if let regionResult = state.regionResult {
-          state.currentNavigation = .flowerDetail(.fromRegionList(regionResult))
-        }
+        state.currentNavigation = .flowerDetail(.fromRegionList)
         return .none
         
       case .binding, .delegate: return .none

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/SubFeature/MapSearchFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/SubFeature/MapSearchFeature.swift
@@ -51,13 +51,6 @@ extension MapSearchFeature {
         }
         return .send(.delegate(.showSearchRegionList(result)))
         
-      case .hideRegionList:
-        if state.isShowRegionList { // 리전 검색 결과 리스트에서 마커 탭 시 바텀시트 정리
-          state.isShowRegionList = false
-          state.currentNavigation = .flowerDetail(.fromRegionList)
-        }
-        return .none
-        
       case .changeRegionSheetDetent:
         if state.isShowRegionList {
           state.regionSheetDetent = .low

--- a/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/MapFeature.swift
@@ -56,20 +56,11 @@ public struct MapFeature {
     /// 현위치 재검색 버튼 활성화 여부
     public var researchButtonEnable: Bool = false
     
-    /// 상세 화면 진입 시 루트 화면
-    public var detailRoot: DetailRoot? = nil
-    /// 리전 검색 결과 저장
-    public var regionResult: RegionInfoEntity? = nil 
-    
     public var toastMessage: String? = nil
     
     public var toastLabel: String? = nil
     
     public var isViewAppeared: Bool = false
-    
-    public var isShowRegionList: Bool = false
-    
-    public var regionSheetDetent: BottomSheetDetent = .medium
     
     public var alertType: AlertType? = nil
 
@@ -102,11 +93,6 @@ public struct MapFeature {
     case fetchPathLines(Int)
     case fetchDetailInfo(Int)
     
-    case showRegionList(data: RegionInfoEntity?)
-    case changeRegionSheetDetent
-    case searchBackButtonTapped
-    case handleSearchBackNavigation
-    
     case presentAlert(type: AlertType)
     case alertCancelTapped
     case alertAcceptTapped(AlertType)
@@ -124,11 +110,6 @@ public struct MapFeature {
     case presentToBlooming(id: Int, streetName: String)
     case presentToLogin(id: Int)
     case mapDidLoad
-  }
-  
-  public enum DetailRoot: Equatable {
-    case region
-    case search
   }
   
   public var body: some ReducerOf<Self> {

--- a/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/MapFeature.swift
@@ -55,15 +55,11 @@ public struct MapFeature {
     public var requestMapBound: Bool = false
     /// 현위치 재검색 버튼 활성화 여부
     public var researchButtonEnable: Bool = false
-    /// 검색 결과 데이터
-    public var searchResult: FlowerSpotEntity? = nil
-    /// 검색 결과 텍스트
-    public var searchText: String? = nil
     
     /// 상세 화면 진입 시 루트 화면
     public var detailRoot: DetailRoot? = nil
     /// 리전 검색 결과 저장
-    public var regionResult: RegionInfoEntity? = nil // TODO: - 추후 타입 변경 필요
+    public var regionResult: RegionInfoEntity? = nil 
     
     public var toastMessage: String? = nil
     
@@ -106,9 +102,6 @@ public struct MapFeature {
     case fetchPathLines(Int)
     case fetchDetailInfo(Int)
     
-    case showSearchResult(FlowerSpotEntity?)
-    case setSearchBarText(String?)
-    case resetSearchBar
     case showRegionList(data: RegionInfoEntity?)
     case changeRegionSheetDetent
     case searchBackButtonTapped
@@ -120,7 +113,6 @@ public struct MapFeature {
     case clearAlertState
     
     case delegate(Delegate)
-    case presentToSearch
     case pushToSetting
   }
   

--- a/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/MapFeature.swift
@@ -19,17 +19,20 @@ import Shared
 public struct MapFeature {
   private let reducer: Reduce<State, Action>
   private let location: Reduce<LocationFeature.State, LocationFeature.Action>
+  private let mapSearch: Reduce<MapSearchFeature.State, MapSearchFeature.Action>
   private let flowerSpotDetail: FlowerSpotDetailFeature
   private let searchRegionList: SearchRegionListFeature
 
   public init(
     reducer: Reduce<State, Action>,
     location: Reduce<LocationFeature.State, LocationFeature.Action>,
+    mapSearch: Reduce<MapSearchFeature.State, MapSearchFeature.Action>,
     flowerSpotDetail: FlowerSpotDetailFeature,
     searchRegionList: SearchRegionListFeature
   ) {
     self.reducer = reducer
     self.location = location
+    self.mapSearch = mapSearch
     self.flowerSpotDetail = flowerSpotDetail
     self.searchRegionList = searchRegionList
   }
@@ -75,6 +78,8 @@ public struct MapFeature {
     public var alertType: AlertType? = nil
 
     public var location: LocationFeature.State = .init()
+    
+    public var mapSearch: MapSearchFeature.State = .init()
 
     /// Optional State 패턴: nil이면 바텀시트 숨김, 값이 있으면 바텀시트 표시
     public var flowerSpotDetail: FlowerSpotDetailFeature.State? = nil
@@ -87,6 +92,7 @@ public struct MapFeature {
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
     case location(LocationFeature.Action)
+    case mapSearch(MapSearchFeature.Action)
     case flowerSpotDetail(FlowerSpotDetailFeature.Action)
     case searchRegionList(SearchRegionListFeature.Action)
     
@@ -137,6 +143,9 @@ public struct MapFeature {
     BindingReducer()
     Scope(state: \.location, action: \.location) {
       location
+    }
+    Scope(state: \.mapSearch, action: \.mapSearch) {
+      mapSearch
     }
     .ifLet(\.flowerSpotDetail, action: \.flowerSpotDetail) {
       flowerSpotDetail

--- a/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/SubFeature/MapSearchFeature.swift
+++ b/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/SubFeature/MapSearchFeature.swift
@@ -26,8 +26,8 @@ public struct MapSearchFeature {
     public var searchResult: FlowerSpotEntity? = nil
     /// 검색 결과 텍스트
     public var searchText: String? = nil
-    /// 상세 화면 진입 시 루트 화면
-    public var detailRoot: DetailRoot? = nil
+    /// 현재 네비게이션 상태
+    public var currentNavigation: NavigationState = .map
     /// 리전 검색 결과 저장
     public var regionResult: RegionInfoEntity? = nil
     /// 리전 검색 리스트 화면 show 여부
@@ -60,6 +60,8 @@ public struct MapSearchFeature {
     case searchBackButtonTapped
     /// SearchBar 뒤로가기 시 화면 전환 처리
     case handleSearchBackNavigation
+    /// 리전리스트에서 상세로 이동 시 네비게이션 상태 설정
+    case setNavigationFromRegionList
     
     case delegate(Delegate)
   }
@@ -72,9 +74,15 @@ public struct MapSearchFeature {
     case dismissFlowerSpotDetil
   }
   
-  public enum DetailRoot: Equatable {
-    case region
-    case search
+  public enum NavigationState: Equatable {
+    case map                                    // 기본 지도 화면
+    case regionList(RegionInfoEntity)          // 리전 검색 결과 리스트
+    case flowerDetail(DetailSource)    // 꽃 상세 화면
+    
+    public enum DetailSource: Equatable {
+      case fromSearch(FlowerSpotEntity)         // 검색에서 온 상세
+      case fromRegionList(RegionInfoEntity)     // 리전리스트에서 온 상세
+    }
   }
   
   public var body: some ReducerOf<Self> {

--- a/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/SubFeature/MapSearchFeature.swift
+++ b/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/SubFeature/MapSearchFeature.swift
@@ -71,7 +71,7 @@ public struct MapSearchFeature {
     case presentToSearch(String?)
     case showSearchRegionList(RegionInfoEntity?)
     case resetMarkerTapped
-    case dismissFlowerSpotDetil
+    case dismissFlowerSpotDetail
   }
   
   public enum NavigationState: Equatable {

--- a/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/SubFeature/MapSearchFeature.swift
+++ b/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/SubFeature/MapSearchFeature.swift
@@ -9,6 +9,7 @@
 import Foundation
 import ComposableArchitecture
 import Shared
+import FlowerSpotClient
 
 @Reducer
 public struct MapSearchFeature {
@@ -19,17 +20,27 @@ public struct MapSearchFeature {
   
   @ObservableState
   public struct State: Equatable {
-    
+    /// 검색 결과 데이터
+    public var searchResult: FlowerSpotEntity? = nil
+    /// 검색 결과 텍스트
+    public var searchText: String? = nil
     public init() {}
   }
   
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
+    
+    case showSearchResult(FlowerSpotEntity?)
+    case setSearchBarText(String?)
+    case resetSearchBar
+    case presentToSearch
+    
     case delegate(Delegate)
   }
   
   public enum Delegate: Equatable {
-    
+    case showSearchResult(FlowerSpotEntity?)
+    case presentToSearch(String?)
   }
   
   public var body: some ReducerOf<Self> {

--- a/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/SubFeature/MapSearchFeature.swift
+++ b/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/SubFeature/MapSearchFeature.swift
@@ -9,7 +9,9 @@
 import Foundation
 import ComposableArchitecture
 import Shared
+import DesignKit
 import FlowerSpotClient
+import SearchClient
 
 @Reducer
 public struct MapSearchFeature {
@@ -24,16 +26,40 @@ public struct MapSearchFeature {
     public var searchResult: FlowerSpotEntity? = nil
     /// 검색 결과 텍스트
     public var searchText: String? = nil
+    /// 상세 화면 진입 시 루트 화면
+    public var detailRoot: DetailRoot? = nil
+    /// 리전 검색 결과 저장
+    public var regionResult: RegionInfoEntity? = nil
+    /// 리전 검색 리스트 화면 show 여부
+    public var isShowRegionList: Bool = false
+    /// 리전 검색 리스트 바텀시트 detent
+    public var regionSheetDetent: BottomSheetDetent = .medium
     public init() {}
   }
   
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
     
-    case showSearchResult(FlowerSpotEntity?)
+    /// 검색 키워드 저장
     case setSearchBarText(String?)
+    /// search bar 키워드 초기화
     case resetSearchBar
+    /// 꽃길 검색 결과
+    case showSearchResult(FlowerSpotEntity?)
+    /// 검색 화면 전환
     case presentToSearch
+    
+    /// 리전 검색 결과
+    case showRegionList(data: RegionInfoEntity?)
+    /// 리전 검색 화면 숨기기 (리전 검색 화면에서 화면 전환 시)
+    case hideRegionList
+    /// 리전 검색 시트 detent 변경
+    case changeRegionSheetDetent
+    
+    /// SearchBar 뒤로가기 버튼 탭
+    case searchBackButtonTapped
+    /// SearchBar 뒤로가기 시 화면 전환 처리
+    case handleSearchBackNavigation
     
     case delegate(Delegate)
   }
@@ -41,6 +67,14 @@ public struct MapSearchFeature {
   public enum Delegate: Equatable {
     case showSearchResult(FlowerSpotEntity?)
     case presentToSearch(String?)
+    case showSearchRegionList(RegionInfoEntity?)
+    case resetMarkerTapped
+    case dismissFlowerSpotDetil
+  }
+  
+  public enum DetailRoot: Equatable {
+    case region
+    case search
   }
   
   public var body: some ReducerOf<Self> {

--- a/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/SubFeature/MapSearchFeature.swift
+++ b/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/SubFeature/MapSearchFeature.swift
@@ -76,12 +76,12 @@ public struct MapSearchFeature {
   
   public enum NavigationState: Equatable {
     case map                                    // 기본 지도 화면
-    case regionList(RegionInfoEntity)          // 리전 검색 결과 리스트
+    case regionList          // 리전 검색 결과 리스트
     case flowerDetail(DetailSource)    // 꽃 상세 화면
     
     public enum DetailSource: Equatable {
-      case fromSearch(FlowerSpotEntity)         // 검색에서 온 상세
-      case fromRegionList(RegionInfoEntity)     // 리전리스트에서 온 상세
+      case fromSearch         // 검색에서 온 상세
+      case fromRegionList     // 리전리스트에서 온 상세
     }
   }
   

--- a/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/SubFeature/MapSearchFeature.swift
+++ b/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/SubFeature/MapSearchFeature.swift
@@ -51,8 +51,6 @@ public struct MapSearchFeature {
     
     /// 리전 검색 결과
     case showRegionList(data: RegionInfoEntity?)
-    /// 리전 검색 화면 숨기기 (리전 검색 화면에서 화면 전환 시)
-    case hideRegionList
     /// 리전 검색 시트 detent 변경
     case changeRegionSheetDetent
     

--- a/Projects/Feature/Map/MapFeatureInterface/Sources/MapView/MapView.swift
+++ b/Projects/Feature/Map/MapFeatureInterface/Sources/MapView/MapView.swift
@@ -67,7 +67,7 @@ public struct MapView: View {
     .overlay {
       Group {
         if let store = store.scope(state: \.searchRegionList, action: \.searchRegionList) {
-          regionListSheet(store: store)
+          regionListSheet(with: store)
         }
       }
     }
@@ -221,12 +221,12 @@ extension MapView {
     )
   }
   
-  private func regionListSheet(store: StoreOf<SearchRegionListFeature>) -> some View {
+  private func regionListSheet(with regionStore: StoreOf<SearchRegionListFeature>) -> some View {
     DetentBottomSheet(
       isPresented: $store.mapSearch.isShowRegionList,
       detent: $store.mapSearch.regionSheetDetent
     ) {
-      SearchRegionListView(store: store)
+      SearchRegionListView(store: regionStore)
     }
   }
 }

--- a/Projects/Feature/Map/MapFeatureInterface/Sources/MapView/MapView.swift
+++ b/Projects/Feature/Map/MapFeatureInterface/Sources/MapView/MapView.swift
@@ -95,7 +95,7 @@ extension MapView {
       newPath: $store.selectedPathLines,
       requestBounds: $store.requestMapBound,
       isCameraMove: $store.researchButtonEnable,
-      focusData: $store.searchResult,
+      focusData: $store.mapSearch.searchResult,
       isNeedDeleteMarker: $store.isNeedDeleteMarker,
       isNeedDrawMarker: $store.isNeedDrawMarker,
       updateMarkerStatus: Binding(
@@ -120,7 +120,7 @@ extension MapView {
   
   @ViewBuilder
   private func searchView() -> some View {
-    if let result = store.searchText { // 검색 결과
+    if let result = store.mapSearch.searchText { // 검색 결과
       SearchBar(
         text: .constant(result),
         placeholder: "",
@@ -134,7 +134,7 @@ extension MapView {
         }
       )
       .onTap {
-        store.send(.presentToSearch)
+        store.send(.mapSearch(.presentToSearch))
       }
     } else { // 검색
       SearchBar(
@@ -145,7 +145,7 @@ extension MapView {
         }
       )
       .onTap {
-        store.send(.presentToSearch)
+        store.send(.mapSearch(.presentToSearch))
       }
     }
   }

--- a/Projects/Feature/Map/MapFeatureInterface/Sources/MapView/MapView.swift
+++ b/Projects/Feature/Map/MapFeatureInterface/Sources/MapView/MapView.swift
@@ -102,7 +102,7 @@ extension MapView {
         get: { store.flowerSpotDetail?.updateMarkerStatus },
         set: { _ in }
       ),
-      hasBottomSheet: $store.isShowRegionList
+      hasBottomSheet: $store.mapSearch.isShowRegionList
     )
     .onReceiveMapBounds {
       if store.requestMapBound {
@@ -113,7 +113,7 @@ extension MapView {
       store.send(.markerTapped(id: id))
     }
     .cameraMoveEvent {
-      store.send(.changeRegionSheetDetent)
+      store.send(.mapSearch(.changeRegionSheetDetent))
     }
     .ignoresSafeArea()
   }
@@ -129,7 +129,7 @@ extension MapView {
           TouchArea(image: .back)
             .size(.extraLarge)
             .action {
-              store.send(.searchBackButtonTapped)
+              store.send(.mapSearch(.searchBackButtonTapped))
             }
         }
       )
@@ -222,7 +222,10 @@ extension MapView {
   }
   
   private func regionListSheet(store: StoreOf<SearchRegionListFeature>) -> some View {
-    DetentBottomSheet(isPresented: $store.isShowRegionList, detent: $store.regionSheetDetent) {
+    DetentBottomSheet(
+      isPresented: $store.mapSearch.isShowRegionList,
+      detent: $store.mapSearch.regionSheetDetent
+    ) {
       SearchRegionListView(store: store)
     }
   }

--- a/Projects/Feature/Map/Project.swift
+++ b/Projects/Feature/Map/Project.swift
@@ -17,6 +17,7 @@ let project = Project.buildFeature(
     .Client.FlowerSpot,
     .Client.Blooming,
     .Client.Location,
+    .Client.Search,
     .SPM.NMap
   ]
 )

--- a/Projects/PIDA/Sources/PIDAFeature.swift
+++ b/Projects/PIDA/Sources/PIDAFeature.swift
@@ -228,7 +228,7 @@ struct PIDAFeature {
           
         case let .selectResult(result):
           return .concatenate(
-            .send(.map(.showSearchResult(result))),
+            .send(.map(.mapSearch(.showSearchResult(result)))),
             .send(.presentSearch(false, keyword: nil))
           )
           

--- a/Projects/PIDA/Sources/PIDAFeature.swift
+++ b/Projects/PIDA/Sources/PIDAFeature.swift
@@ -52,6 +52,7 @@ struct PIDAFeature {
   @Dependency(\.userClient) var userClient
 
   let locationReducer = Reduce(LocationFeature())
+  let mapSearchReducer = Reduce(MapSearchFeature())
   
   @ObservableState
   struct State: Equatable {
@@ -123,6 +124,7 @@ struct PIDAFeature {
     Scope(state: \.map, action: \.map) {
       MapFeature(
         location: locationReducer,
+        mapSearch: mapSearchReducer,
         flowerSpotDetail: FlowerSpotDetailFeature(),
         searchRegionList: SearchRegionListFeature()
       )

--- a/Projects/PIDA/Sources/PIDAFeature.swift
+++ b/Projects/PIDA/Sources/PIDAFeature.swift
@@ -234,7 +234,7 @@ struct PIDAFeature {
           
         case let .selectRegionResult(result):
           return .concatenate(
-            .send(.map(.showRegionList(data: result))),
+            .send(.map(.mapSearch(.showRegionList(data: result)))),
             .send(.presentSearch(false, keyword: nil))
           )
         }


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #105 

## 🔎 작업 내용
### 검색 상태 및 액션 분리
- 검색 관련 state와 action을 MapSearchFeature로 이동
- MapSearchFeature를 MapFeature의 하위로 등록

### 검색 관련 네비게이션 로직 개선
> 지도 -> 검색 -> 꽃길 -> 디테일
> 지도 -> 검색 -> 리전 리스트 -> 디테일

이 두 케이스에 따라 SearchBar의 backbutton 탭 시 화면 이동 처리 과정이 필요
기존에는 상세 화면을 어디에서 들어왔는지에 따라 나눴는데, 코드 가독성이 좋지않았음.
현재 화면이 어디인지를 나타내는 enum을 보다 명확하게 정의하여 개선함.
```swift
public enum NavigationState: Equatable {
    case map                                    // 기본 지도 화면
    case regionList(RegionInfoEntity)          // 리전 검색 결과 리스트
    case flowerDetail(DetailSource)    // 꽃 상세 화면
    
    public enum DetailSource: Equatable {
      case fromSearch(FlowerSpotEntity)         // 검색에서 온 상세
      case fromRegionList(RegionInfoEntity)     // 리전리스트에서 온 상세
    }
  }
```

## 📷 스크린샷

## 🛠️ 기타 공유 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Search functionality reorganized into a dedicated search component integrated with the map, delegating marker taps, search results, and region-list navigation to that component.
  * Region list sheet behavior and back-navigation flows updated for more consistent presentation and navigation between map, region list, and detail views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->