### PR TITLE
Feature/#107 믹스패널 이벤트 설계 및 조합

### DIFF
--- a/Config/Debug.xcconfig
+++ b/Config/Debug.xcconfig
@@ -6,3 +6,4 @@ SWIFT_OPTIMIZATION_LEVEL = -Onone
 #include? "Debug-Secrets.xcconfig"
 NM_CLIENT_ID = ${NM_CLIENT_ID}
 BASE_URL = ${BASE_URL}
+MIXPANEL_TOKEN = ${MIXPANEL_TOKEN}

--- a/Config/Release.xcconfig
+++ b/Config/Release.xcconfig
@@ -5,3 +5,4 @@ SWIFT_OPTIMIZATION_LEVEL = -Owholemodule
 #include? "Release-Secrets.xcconfig"
 NM_CLIENT_ID = ${NM_CLIENT_ID}
 BASE_URL = ${BASE_URL}
+MIXPANEL_TOKEN = ${MIXPANEL_TOKEN}

--- a/Projects/Client/Analytics/Project.swift
+++ b/Projects/Client/Analytics/Project.swift
@@ -1,0 +1,17 @@
+//
+//  Project.swift
+//  AnalyticsClient
+//
+//  Created by 조용인 on 1/27/26.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.buildStaticLibrary(
+  for: Client.Analytics,
+  dependencies: [
+    .SPM.TCA,
+    .SPM.Mixpanel
+  ]
+)

--- a/Projects/Client/Analytics/Sources/Client/AnalyticsClient+Live.swift
+++ b/Projects/Client/Analytics/Sources/Client/AnalyticsClient+Live.swift
@@ -37,7 +37,7 @@ extension AnalyticsClient: DependencyKey {
   }()
 }
 
-// MARK: - Preview/Test Value
+// MARK: - Preview Value
 
 extension AnalyticsClient {
   public static let previewValue: AnalyticsClient = {
@@ -48,17 +48,6 @@ extension AnalyticsClient {
         print("[Analytics Preview] \(event.name): \(event.properties)")
         #endif
       },
-      identify: { _ in },
-      setUserProperties: { _ in },
-      reset: { },
-      setSuperProperties: { _ in }
-    )
-  }()
-
-  public static let testValue: AnalyticsClient = {
-    AnalyticsClient(
-      initialize: { _ in },
-      track: { _ in },
       identify: { _ in },
       setUserProperties: { _ in },
       reset: { },

--- a/Projects/Client/Analytics/Sources/Client/AnalyticsClient+Live.swift
+++ b/Projects/Client/Analytics/Sources/Client/AnalyticsClient+Live.swift
@@ -1,0 +1,68 @@
+//
+//  AnalyticsClient+Live.swift
+//  AnalyticsClient
+//
+//  Created by 조용인 on 1/27/26.
+//
+
+import ComposableArchitecture
+import Foundation
+
+// MARK: - DependencyKey
+
+extension AnalyticsClient: DependencyKey {
+  public static let liveValue: AnalyticsClient = {
+    let provider = MixpanelProvider()
+
+    return AnalyticsClient(
+      initialize: { token in
+        provider.initialize(token: token)
+      },
+      track: { event in
+        provider.track(event)
+      },
+      identify: { userId in
+        provider.identify(userId: userId)
+      },
+      setUserProperties: { properties in
+        provider.setUserProperties(properties)
+      },
+      reset: {
+        provider.reset()
+      },
+      setSuperProperties: { properties in
+        provider.setSuperProperties(properties)
+      }
+    )
+  }()
+}
+
+// MARK: - Preview/Test Value
+
+extension AnalyticsClient {
+  public static let previewValue: AnalyticsClient = {
+    AnalyticsClient(
+      initialize: { _ in },
+      track: { event in
+        #if DEBUG
+        print("[Analytics Preview] \(event.name): \(event.properties)")
+        #endif
+      },
+      identify: { _ in },
+      setUserProperties: { _ in },
+      reset: { },
+      setSuperProperties: { _ in }
+    )
+  }()
+
+  public static let testValue: AnalyticsClient = {
+    AnalyticsClient(
+      initialize: { _ in },
+      track: { _ in },
+      identify: { _ in },
+      setUserProperties: { _ in },
+      reset: { },
+      setSuperProperties: { _ in }
+    )
+  }()
+}

--- a/Projects/Client/Analytics/Sources/Client/AnalyticsClient.swift
+++ b/Projects/Client/Analytics/Sources/Client/AnalyticsClient.swift
@@ -1,0 +1,41 @@
+//
+//  AnalyticsClient.swift
+//  AnalyticsClient
+//
+//  Created by 조용인 on 1/27/26.
+//
+
+import ComposableArchitecture
+import Foundation
+
+// MARK: - AnalyticsClient
+
+@DependencyClient
+public struct AnalyticsClient: Sendable {
+  /// SDK 초기화 (AppDelegate에서 호출)
+  public var initialize: @Sendable (_ token: String) -> Void
+
+  /// 이벤트 트래킹
+  public var track: @Sendable (_ event: any AnalyticsEvent) -> Void
+
+  /// 사용자 식별 (로그인 시)
+  public var identify: @Sendable (_ userId: String) -> Void
+
+  /// 사용자 프로필 업데이트
+  public var setUserProperties: @Sendable (_ properties: [String: Any]) -> Void
+
+  /// 사용자 식별 해제 (로그아웃 시)
+  public var reset: @Sendable () -> Void
+
+  /// Super Properties 설정 (모든 이벤트에 자동 포함)
+  public var setSuperProperties: @Sendable (_ properties: [String: Any]) -> Void
+}
+
+// MARK: - DependencyValues
+
+public extension DependencyValues {
+  var analyticsClient: AnalyticsClient {
+    get { self[AnalyticsClient.self] }
+    set { self[AnalyticsClient.self] = newValue }
+  }
+}

--- a/Projects/Client/Analytics/Sources/Event/AnalyticsEvent.swift
+++ b/Projects/Client/Analytics/Sources/Event/AnalyticsEvent.swift
@@ -1,0 +1,26 @@
+//
+//  AnalyticsEvent.swift
+//  AnalyticsClient
+//
+//  Created by 조용인 on 1/27/26.
+//
+
+import Foundation
+
+// MARK: - AnalyticsEvent
+
+/// 분석 이벤트 프로토콜 (OCP 준수)
+/// 새로운 이벤트 추가 시 이 프로토콜을 준수하는 enum 생성
+public protocol AnalyticsEvent: Sendable {
+  /// 이벤트 이름 (snake_case)
+  var name: String { get }
+
+  /// 이벤트 고유 속성 (Super Properties 제외)
+  var properties: [String: Any] { get }
+}
+
+// MARK: - Default Implementation
+
+public extension AnalyticsEvent {
+  var properties: [String: Any] { [:] }
+}

--- a/Projects/Client/Analytics/Sources/Event/AnalyticsEvent.swift
+++ b/Projects/Client/Analytics/Sources/Event/AnalyticsEvent.swift
@@ -11,11 +11,16 @@ import Foundation
 
 /// 분석 이벤트 프로토콜 (OCP 준수)
 /// 새로운 이벤트 추가 시 이 프로토콜을 준수하는 enum 생성
+///
+/// - Warning: `properties`는 Sendable 타입만 포함해야 합니다.
+///            허용 타입: `String`, `Int`, `Double`, `Bool`, `Date`, `URL`
+///            Mixpanel SDK API 제약으로 `[String: Any]`를 사용합니다.
 public protocol AnalyticsEvent: Sendable {
   /// 이벤트 이름 (snake_case)
   var name: String { get }
 
   /// 이벤트 고유 속성 (Super Properties 제외)
+  /// - Note: Sendable 타입만 포함해야 합니다.
   var properties: [String: Any] { get }
 }
 

--- a/Projects/Client/Analytics/Sources/Event/BloomingEvent.swift
+++ b/Projects/Client/Analytics/Sources/Event/BloomingEvent.swift
@@ -1,0 +1,101 @@
+//
+//  BloomingEvent.swift
+//  AnalyticsClient
+//
+//  Created by 조용인 on 1/27/26.
+//
+
+import Foundation
+
+// MARK: - BloomingEvent
+
+/// 개화 상태 투표 관련 이벤트
+public enum BloomingEvent: AnalyticsEvent {
+  /// 투표 화면 진입
+  case updateStart(
+    spotId: Int,
+    distanceFromSpot: Double?
+  )
+
+  /// 개화 상태 옵션 중 하나를 터치
+  case statusOption(
+    distanceFromSpot: Double?,
+    statusOption: StatusOption
+  )
+
+  /// '한 컷 공유하기' 버튼 터치
+  case uploadPhoto(
+    distanceFromSpot: Double?,
+    isStatusRecorded: Bool
+  )
+
+  /// '기록하기' 버튼 눌러 제출 완료
+  case statusSubmitted(
+    distanceFromSpot: Double?,
+    completeDurationSeconds: Double
+  )
+
+  public var name: String {
+    switch self {
+    case .updateStart:
+      return "update_start"
+    case .statusOption:
+      return "bloom_status_option"
+    case .uploadPhoto:
+      return "upload_photo"
+    case .statusSubmitted:
+      return "bloom_status_submitted"
+    }
+  }
+
+  public var properties: [String: Any] {
+    switch self {
+    case let .updateStart(spotId, distanceFromSpot):
+      var props: [String: Any] = ["spot_id": spotId]
+
+      if let distanceFromSpot {
+        props["distance_from_spot"] = distanceFromSpot
+      }
+
+      return props
+
+    case let .statusOption(distanceFromSpot, statusOption):
+      var props: [String: Any] = ["status_option": statusOption.rawValue]
+
+      if let distanceFromSpot {
+        props["distance_from_spot"] = distanceFromSpot
+      }
+
+      return props
+
+    case let .uploadPhoto(distanceFromSpot, isStatusRecorded):
+      var props: [String: Any] = ["is_status_recorded": isStatusRecorded]
+
+      if let distanceFromSpot {
+        props["distance_from_spot"] = distanceFromSpot
+      }
+
+      return props
+
+    case let .statusSubmitted(distanceFromSpot, completeDurationSeconds):
+      var props: [String: Any] = ["complete_duration_seconds": completeDurationSeconds]
+
+      if let distanceFromSpot {
+        props["distance_from_spot"] = distanceFromSpot
+      }
+
+      return props
+    }
+  }
+}
+
+// MARK: - StatusOption
+
+public extension BloomingEvent {
+  /// 개화 상태 옵션
+  enum StatusOption: String, Sendable {
+    case notYet = "not_yet"           // 아직이에요
+    case fullBloom = "full_bloom"     // 만개예요!
+    case fallen = "fallen"            // 져물었어요...
+  }
+}

--- a/Projects/Client/Analytics/Sources/Event/DetailsEvent.swift
+++ b/Projects/Client/Analytics/Sources/Event/DetailsEvent.swift
@@ -43,15 +43,15 @@ public enum DetailsEvent: AnalyticsEvent {
     case .start:
       return "details_start"
     case .scrollReachBottom:
-      return "scroll_reach_bottom"
+      return "details_scroll_reach_bottom"
     case .copyAddress:
-      return "copy_address"
+      return "details_copy_address"
     case .thumbnailClicked:
       return "details_thumbnail_clicked"
     case .galleryStart:
-      return "gallery_start"
+      return "details_gallery_start"
     case .viewerStart:
-      return "viewer_start"
+      return "details_viewer_start"
     }
   }
 

--- a/Projects/Client/Analytics/Sources/Event/DetailsEvent.swift
+++ b/Projects/Client/Analytics/Sources/Event/DetailsEvent.swift
@@ -1,0 +1,104 @@
+//
+//  DetailsEvent.swift
+//  AnalyticsClient
+//
+//  Created by 조용인 on 1/27/26.
+//
+
+import Foundation
+
+// MARK: - DetailsEvent
+
+/// 상세 페이지 관련 이벤트
+public enum DetailsEvent: AnalyticsEvent {
+  /// 상세 페이지 진입
+  case start(
+    spotId: Int,
+    distanceFromSpot: Double?,
+    currentBloomStatus: String?,
+    visitCount: Int
+  )
+
+  /// 하단 '나무 종류' 영역이 화면에 노출됐을 때
+  case scrollReachBottom(scrollTimeToReach: Double)
+
+  /// 주소 옆 '복사' 버튼 클릭
+  case copyAddress(
+    scrollTimeToReach: Double,
+    copyAddressCount: Int,
+    copyAddressToUpdate: Int
+  )
+
+  /// 상단 썸네일 사진 클릭
+  case thumbnailClicked(spotPhoto: Int)
+
+  /// 갤러리 화면 진입
+  case galleryStart(distanceFromSpot: Double?)
+
+  /// 사진 뷰어 화면 진입
+  case viewerStart(distanceFromSpot: Double?)
+
+  public var name: String {
+    switch self {
+    case .start:
+      return "details_start"
+    case .scrollReachBottom:
+      return "scroll_reach_bottom"
+    case .copyAddress:
+      return "copy_address"
+    case .thumbnailClicked:
+      return "details_thumbnail_clicked"
+    case .galleryStart:
+      return "gallery_start"
+    case .viewerStart:
+      return "viewer_start"
+    }
+  }
+
+  public var properties: [String: Any] {
+    switch self {
+    case let .start(spotId, distanceFromSpot, currentBloomStatus, visitCount):
+      var props: [String: Any] = [
+        "spot_id": spotId,
+        "visit_count": visitCount
+      ]
+
+      if let distanceFromSpot {
+        props["distance_from_spot"] = distanceFromSpot
+      }
+
+      if let currentBloomStatus {
+        props["current_bloom_status"] = currentBloomStatus
+      }
+
+      return props
+
+    case let .scrollReachBottom(scrollTimeToReach):
+      return ["scroll_time_to_reach": scrollTimeToReach]
+
+    case let .copyAddress(scrollTimeToReach, copyAddressCount, copyAddressToUpdate):
+      return [
+        "scroll_time_to_reach": scrollTimeToReach,
+        "copy_address_count": copyAddressCount,
+        "copy_address_to_update": copyAddressToUpdate
+      ]
+
+    case let .thumbnailClicked(spotPhoto):
+      return ["spot_photo": spotPhoto]
+
+    case let .galleryStart(distanceFromSpot):
+      var props: [String: Any] = [:]
+      if let distanceFromSpot {
+        props["distance_from_spot"] = distanceFromSpot
+      }
+      return props
+
+    case let .viewerStart(distanceFromSpot):
+      var props: [String: Any] = [:]
+      if let distanceFromSpot {
+        props["distance_from_spot"] = distanceFromSpot
+      }
+      return props
+    }
+  }
+}

--- a/Projects/Client/Analytics/Sources/Event/MapEvent.swift
+++ b/Projects/Client/Analytics/Sources/Event/MapEvent.swift
@@ -1,0 +1,92 @@
+//
+//  MapEvent.swift
+//  AnalyticsClient
+//
+//  Created by 조용인 on 1/27/26.
+//
+
+import Foundation
+
+// MARK: - MapEvent
+
+/// 지도 관련 이벤트
+public enum MapEvent: AnalyticsEvent {
+  /// 바텀시트 열렸을 때 (꽃길 핀 선택)
+  case spotSelected(
+    spotId: Int,
+    distanceFromSpot: Double?,
+    currentBloomStatus: String?,
+    visitCount: Int,
+    entryPoint: EntryPoint
+  )
+
+  /// 우측 하단 '현위치로 이동' 버튼 클릭
+  case currentLocationClicked(currentPage: String)
+
+  /// '현 위치에서 재검색' 버튼 클릭
+  case researchClicked(currentPage: String)
+
+  /// '현 위치에서 재검색' 버튼 클릭했으나 꽃길이 주변에 없는 경우
+  case researchFailed
+
+  /// '제보하기' 버튼 클릭
+  case reportClicked
+
+  public var name: String {
+    switch self {
+    case .spotSelected:
+      return "map_spot_selected"
+    case .currentLocationClicked:
+      return "map_current_location_clicked"
+    case .researchClicked:
+      return "map_research_clicked"
+    case .researchFailed:
+      return "map_research_failed"
+    case .reportClicked:
+      return "map_report_clicked"
+    }
+  }
+
+  public var properties: [String: Any] {
+    switch self {
+    case let .spotSelected(spotId, distanceFromSpot, currentBloomStatus, visitCount, entryPoint):
+      var props: [String: Any] = [
+        "spot_id": spotId,
+        "visit_count": visitCount,
+        "entry_point": entryPoint.rawValue
+      ]
+
+      if let distanceFromSpot {
+        props["distance_from_spot"] = distanceFromSpot
+      }
+
+      if let currentBloomStatus {
+        props["current_bloom_status"] = currentBloomStatus
+      }
+
+      return props
+
+    case let .currentLocationClicked(currentPage):
+      return ["current_page": currentPage]
+
+    case let .researchClicked(currentPage):
+      return ["current_page": currentPage]
+
+    case .researchFailed, .reportClicked:
+      return [:]
+    }
+  }
+}
+
+// MARK: - EntryPoint
+
+public extension MapEvent {
+  /// 바텀시트가 열릴 때 사용자가 해당 벚꽃길을 선택하기 이전 경로
+  enum EntryPoint: String, Sendable {
+    case mapPin = "map_pin"
+    case searchRecent = "search_recent"
+    case searchKeyword = "search_keyword"
+    case searchRegion = "search_region"
+    case keyboard = "keyboard"
+  }
+}

--- a/Projects/Client/Analytics/Sources/Event/SearchEvent.swift
+++ b/Projects/Client/Analytics/Sources/Event/SearchEvent.swift
@@ -1,0 +1,143 @@
+//
+//  SearchEvent.swift
+//  AnalyticsClient
+//
+//  Created by 조용인 on 1/27/26.
+//
+
+import Foundation
+
+// MARK: - SearchEvent
+
+/// 검색 관련 이벤트
+public enum SearchEvent: AnalyticsEvent {
+  /// 검색창 클릭하여 검색 화면 진입
+  case start(
+    hasRecentSearches: Bool,
+    recentSearchesCount: Int,
+    entryPoint: String
+  )
+
+  /// 최근 검색어 항목 클릭
+  case recentSearchClicked
+
+  /// 검색어 입력 시작
+  case input
+
+  /// keyboard에서 검색 버튼 클릭
+  case inputSubmitted(resultType: ResultType)
+
+  /// 검색 자동완성 항목 클릭
+  case suggestionClicked(resultType: ResultType)
+
+  /// 검색 결과 없음 화면 진입
+  case noResultViewed(keywordLength: Int, resultType: ResultType)
+
+  /// 검색 결과 리스트에서 region 선택하여 지도 화면 진입
+  case resultViewed(
+    entryPoint: String,
+    distanceFromRegion: Double?,
+    scrollItemCount: Int
+  )
+
+  /// 검색 결과 목록 스크롤 발생
+  case resultScrolled(
+    researchResult: String?,
+    currentPage: String,
+    resultType: ResultType
+  )
+
+  /// 검색 결과 화면에서 '현 위치에서 재검색' 버튼 클릭
+  case researchClicked(currentPage: String)
+
+  /// 검색 결과 리스트에서 항목 클릭
+  case resultClicked
+
+  public var name: String {
+    switch self {
+    case .start:
+      return "search_start"
+    case .recentSearchClicked:
+      return "recent_search_clicked"
+    case .input:
+      return "search_input"
+    case .inputSubmitted:
+      return "search_input_submitted"
+    case .suggestionClicked:
+      return "search_suggestion_clicked"
+    case .noResultViewed:
+      return "search_no_result_viewed"
+    case .resultViewed:
+      return "search_result_viewed"
+    case .resultScrolled:
+      return "search_result_scrolled"
+    case .researchClicked:
+      return "search_research_clicked"
+    case .resultClicked:
+      return "search_result_clicked"
+    }
+  }
+
+  public var properties: [String: Any] {
+    switch self {
+    case let .start(hasRecentSearches, recentSearchesCount, entryPoint):
+      return [
+        "has_recent_searches": hasRecentSearches,
+        "recent_searches_count": recentSearchesCount,
+        "entry_point": entryPoint
+      ]
+
+    case .recentSearchClicked, .input, .resultClicked:
+      return [:]
+
+    case let .inputSubmitted(resultType):
+      return ["result_type": resultType.rawValue]
+
+    case let .suggestionClicked(resultType):
+      return ["result_type": resultType.rawValue]
+
+    case let .noResultViewed(keywordLength, resultType):
+      return [
+        "keyword_length": keywordLength,
+        "result_type": resultType.rawValue
+      ]
+
+    case let .resultViewed(entryPoint, distanceFromRegion, scrollItemCount):
+      var props: [String: Any] = [
+        "entry_point": entryPoint,
+        "scroll_item_count": scrollItemCount
+      ]
+
+      if let distanceFromRegion {
+        props["distance_from_region"] = distanceFromRegion
+      }
+
+      return props
+
+    case let .resultScrolled(researchResult, currentPage, resultType):
+      var props: [String: Any] = [
+        "current_page": currentPage,
+        "result_type": resultType.rawValue
+      ]
+
+      if let researchResult {
+        props["research_result"] = researchResult
+      }
+
+      return props
+
+    case let .researchClicked(currentPage):
+      return ["current_page": currentPage]
+    }
+  }
+}
+
+// MARK: - ResultType
+
+public extension SearchEvent {
+  /// 검색어 타입 (행정구역, 랜드마크)
+  enum ResultType: String, Sendable {
+    case region = "region"
+    case landmark = "landmark"
+  }
+}

--- a/Projects/Client/Analytics/Sources/Event/SessionEvent.swift
+++ b/Projects/Client/Analytics/Sources/Event/SessionEvent.swift
@@ -1,0 +1,46 @@
+//
+//  SessionEvent.swift
+//  AnalyticsClient
+//
+//  Created by 조용인 on 1/27/26.
+//
+
+import Foundation
+
+// MARK: - SessionEvent
+
+/// 세션 관련 이벤트
+public enum SessionEvent: AnalyticsEvent {
+  /// 세션 시작, 메인 화면 진입
+  case start(
+    sessionDuration: Int?,
+    sessionPreviousGap: Int?,
+    userLocationEnabled: Bool
+  )
+
+  public var name: String {
+    switch self {
+    case .start:
+      return "session_start"
+    }
+  }
+
+  public var properties: [String: Any] {
+    switch self {
+    case let .start(sessionDuration, sessionPreviousGap, userLocationEnabled):
+      var props: [String: Any] = [
+        "user_location_enabled": userLocationEnabled
+      ]
+
+      if let sessionDuration {
+        props["session_duration"] = sessionDuration
+      }
+
+      if let sessionPreviousGap {
+        props["session_previous_gap"] = sessionPreviousGap
+      }
+
+      return props
+    }
+  }
+}

--- a/Projects/Client/Analytics/Sources/Event/SuperProperties.swift
+++ b/Projects/Client/Analytics/Sources/Event/SuperProperties.swift
@@ -95,11 +95,10 @@ private enum DeviceInfo {
   static var modelName: String {
     var systemInfo = utsname()
     uname(&systemInfo)
-    let machineMirror = Mirror(reflecting: systemInfo.machine)
-    let identifier = machineMirror.children.reduce("") { identifier, element in
-      guard let value = element.value as? Int8, value != 0 else { return identifier }
-      return identifier + String(UnicodeScalar(UInt8(value)))
+    return withUnsafePointer(to: &systemInfo.machine) {
+      $0.withMemoryRebound(to: CChar.self, capacity: 1) {
+        String(validatingUTF8: $0) ?? "unknown"
+      }
     }
-    return identifier
   }
 }

--- a/Projects/Client/Analytics/Sources/Event/SuperProperties.swift
+++ b/Projects/Client/Analytics/Sources/Event/SuperProperties.swift
@@ -1,0 +1,105 @@
+//
+//  SuperProperties.swift
+//  AnalyticsClient
+//
+//  Created by 조용인 on 1/27/26.
+//
+
+import Foundation
+
+// MARK: - SuperProperties
+
+/// 모든 이벤트에 자동으로 포함되는 공통 속성
+public struct SuperProperties: Sendable {
+  public let userId: String?
+  public let userLogin: Bool
+  public let userRegion: String?
+  public let appVersion: String
+  public let osVersion: String
+  public let deviceModel: String
+  public let sessionId: String
+
+  public init(
+    userId: String?,
+    userLogin: Bool,
+    userRegion: String?,
+    appVersion: String,
+    osVersion: String,
+    deviceModel: String,
+    sessionId: String
+  ) {
+    self.userId = userId
+    self.userLogin = userLogin
+    self.userRegion = userRegion
+    self.appVersion = appVersion
+    self.osVersion = osVersion
+    self.deviceModel = deviceModel
+    self.sessionId = sessionId
+  }
+
+  /// Dictionary 변환
+  public var asDictionary: [String: Any] {
+    var dict: [String: Any] = [
+      "user_login": userLogin,
+      "app_version": appVersion,
+      "os_version": osVersion,
+      "device_model": deviceModel,
+      "session_id": sessionId
+    ]
+
+    if let userId {
+      dict["user_id"] = userId
+    }
+
+    if let userRegion {
+      dict["user_region"] = userRegion
+    }
+
+    return dict
+  }
+}
+
+// MARK: - SuperProperties Builder
+
+public extension SuperProperties {
+  /// 현재 기기 정보로 SuperProperties 생성
+  static func current(
+    userId: String?,
+    userLogin: Bool,
+    userRegion: String?,
+    sessionId: String = UUID().uuidString
+  ) -> SuperProperties {
+    SuperProperties(
+      userId: userId,
+      userLogin: userLogin,
+      userRegion: userRegion,
+      appVersion: Bundle.main.appVersion,
+      osVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+      deviceModel: DeviceInfo.modelName,
+      sessionId: sessionId
+    )
+  }
+}
+
+// MARK: - Bundle Extension
+
+private extension Bundle {
+  var appVersion: String {
+    infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+  }
+}
+
+// MARK: - DeviceInfo
+
+private enum DeviceInfo {
+  static var modelName: String {
+    var systemInfo = utsname()
+    uname(&systemInfo)
+    let machineMirror = Mirror(reflecting: systemInfo.machine)
+    let identifier = machineMirror.children.reduce("") { identifier, element in
+      guard let value = element.value as? Int8, value != 0 else { return identifier }
+      return identifier + String(UnicodeScalar(UInt8(value)))
+    }
+    return identifier
+  }
+}

--- a/Projects/Client/Analytics/Sources/Provider/AnalyticsProvider.swift
+++ b/Projects/Client/Analytics/Sources/Provider/AnalyticsProvider.swift
@@ -1,0 +1,32 @@
+//
+//  AnalyticsProvider.swift
+//  AnalyticsClient
+//
+//  Created by 조용인 on 1/27/26.
+//
+
+import Foundation
+
+// MARK: - AnalyticsProvider
+
+/// 분석 도구 추상화 프로토콜 (OCP 준수)
+/// 새로운 분석 도구 추가 시 이 프로토콜을 구현
+public protocol AnalyticsProvider: Sendable {
+  /// SDK 초기화
+  func initialize(token: String)
+
+  /// 이벤트 트래킹
+  func track(_ event: any AnalyticsEvent)
+
+  /// 사용자 식별
+  func identify(userId: String)
+
+  /// 사용자 프로필 설정
+  func setUserProperties(_ properties: [String: Any])
+
+  /// 사용자 식별 해제
+  func reset()
+
+  /// Super Properties 설정
+  func setSuperProperties(_ properties: [String: Any])
+}

--- a/Projects/Client/Analytics/Sources/Provider/MixpanelProvider.swift
+++ b/Projects/Client/Analytics/Sources/Provider/MixpanelProvider.swift
@@ -11,6 +11,10 @@ import Mixpanel
 // MARK: - MixpanelProvider
 
 /// Mixpanel SDK 래핑 Provider
+///
+/// - Note: Mixpanel SDK는 내부적으로 thread-safe하게 구현되어 있어
+///         `@unchecked Sendable`로 선언해도 안전합니다.
+///         https://github.com/mixpanel/mixpanel-swift
 public final class MixpanelProvider: AnalyticsProvider, @unchecked Sendable {
   public init() {}
 

--- a/Projects/Client/Analytics/Sources/Provider/MixpanelProvider.swift
+++ b/Projects/Client/Analytics/Sources/Provider/MixpanelProvider.swift
@@ -1,0 +1,79 @@
+//
+//  MixpanelProvider.swift
+//  AnalyticsClient
+//
+//  Created by 조용인 on 1/27/26.
+//
+
+import Foundation
+import Mixpanel
+
+// MARK: - MixpanelProvider
+
+/// Mixpanel SDK 래핑 Provider
+public final class MixpanelProvider: AnalyticsProvider, @unchecked Sendable {
+  public init() {}
+
+  public func initialize(token: String) {
+    Mixpanel.initialize(token: token, trackAutomaticEvents: false)
+  }
+
+  public func track(_ event: any AnalyticsEvent) {
+    let properties = convertToMixpanelProperties(event.properties)
+    Mixpanel.mainInstance().track(event: event.name, properties: properties)
+
+    #if DEBUG
+    print("[Analytics] \(event.name): \(event.properties)")
+    #endif
+  }
+
+  public func identify(userId: String) {
+    Mixpanel.mainInstance().identify(distinctId: userId)
+  }
+
+  public func setUserProperties(_ properties: [String: Any]) {
+    let mixpanelProperties = convertToMixpanelProperties(properties)
+    Mixpanel.mainInstance().people.set(properties: mixpanelProperties)
+  }
+
+  public func reset() {
+    Mixpanel.mainInstance().reset()
+  }
+
+  public func setSuperProperties(_ properties: [String: Any]) {
+    let mixpanelProperties = convertToMixpanelProperties(properties)
+    Mixpanel.mainInstance().registerSuperProperties(mixpanelProperties)
+  }
+}
+
+// MARK: - Private Helpers
+
+private extension MixpanelProvider {
+  /// [String: Any]를 Mixpanel 호환 타입으로 변환
+  func convertToMixpanelProperties(_ properties: [String: Any]) -> [String: MixpanelType] {
+    properties.compactMapValues { value -> MixpanelType? in
+      switch value {
+      case let string as String:
+        return string
+      case let int as Int:
+        return int
+      case let double as Double:
+        return double
+      case let float as Float:
+        return float
+      case let bool as Bool:
+        return bool
+      case let date as Date:
+        return date
+      case let url as URL:
+        return url
+      case let array as [MixpanelType]:
+        return array
+      case let dict as [String: MixpanelType]:
+        return dict
+      default:
+        return String(describing: value)
+      }
+    }
+  }
+}

--- a/Projects/Client/Location/Sources/Client/LocationClient+Live.swift
+++ b/Projects/Client/Location/Sources/Client/LocationClient+Live.swift
@@ -7,12 +7,17 @@
 //
 
 import ComposableArchitecture
+import CoreLocation
 
 extension LocationClient: DependencyKey {
   public static var liveValue: Self {
     return .init(
-      requestUserLocation: { 
+      requestUserLocation: {
         await LocationService().requestUserLocation()
+      },
+      checkAuthorizationStatus: {
+        let status = CLLocationManager().authorizationStatus
+        return status == .authorizedAlways || status == .authorizedWhenInUse
       }
     )
   }

--- a/Projects/Client/Location/Sources/Client/LocationClient.swift
+++ b/Projects/Client/Location/Sources/Client/LocationClient.swift
@@ -12,6 +12,7 @@ import Shared
 @DependencyClient
 public struct LocationClient: Sendable {
   public var requestUserLocation: @Sendable () async -> Coordinate?
+  public var checkAuthorizationStatus: @Sendable () -> Bool = { false }
 }
 
 public extension DependencyValues {

--- a/Projects/Feature/Blooming/BloomingFeature/Sources/BloomingUpdateFeature.swift
+++ b/Projects/Feature/Blooming/BloomingFeature/Sources/BloomingUpdateFeature.swift
@@ -13,6 +13,7 @@ import BloomingFeatureInterface
 import BloomingClient
 import APIClient
 import DesignKit
+import AnalyticsClient
 
 extension BloomingUpdateFeature {
   public init() {
@@ -23,10 +24,44 @@ extension BloomingUpdateFeature {
     @Dependency(\.bloomingClient) var bloomingClient
     @Dependency(\.apiClient) var apiClient
     @Dependency(\.mainQueue) var mainQueue
+    @Dependency(\.analyticsClient) var analyticsClient
 
     func reduce(into state: inout State, action: Action) -> Effect<Action> {
       switch action {
+      case .onAppear:
+        state.updateStartTime = Date()
+        // update_start 이벤트 트래킹
+        if let spotId = state.spotId {
+          analyticsClient.track(
+            BloomingEvent.updateStart(
+              spotId: spotId,
+              distanceFromSpot: state.distanceFromSpot
+            )
+          )
+        }
+        return .none
+
       case .binding(\.selectedStatus):
+        // bloom_status_option 이벤트 트래킹
+        if let status = state.selectedStatus {
+          let statusOption: BloomingEvent.StatusOption
+          switch status {
+          case .little:
+            statusOption = .notYet
+          case .bloomed:
+            statusOption = .fullBloom
+          case .withered:
+            statusOption = .fallen
+          case .notBloomed:
+            statusOption = .notYet
+          }
+          analyticsClient.track(
+            BloomingEvent.statusOption(
+              distanceFromSpot: state.distanceFromSpot,
+              statusOption: statusOption
+            )
+          )
+        }
         return .send(.changeStatus)
 
       case .changeStatus:
@@ -66,7 +101,9 @@ extension BloomingUpdateFeature {
         return updateBloomingRequest(
           id: id,
           status: status,
-          imageData: state.selectedImageData
+          imageData: state.selectedImageData,
+          distanceFromSpot: state.distanceFromSpot,
+          updateStartTime: state.updateStartTime
         )
 
       case let .dismiss(update, spotId):
@@ -79,6 +116,13 @@ extension BloomingUpdateFeature {
 
       case .photoButtonTapped:
         state.isPhotoPickerPresented = true
+        // upload_photo 이벤트 트래킹
+        analyticsClient.track(
+          BloomingEvent.uploadPhoto(
+            distanceFromSpot: state.distanceFromSpot,
+            isStatusRecorded: state.selectedStatus != nil
+          )
+        )
         return .none
 
       case .photoRemoveButtonTapped:
@@ -115,13 +159,29 @@ extension BloomingUpdateFeature.Core {
   private func updateBloomingRequest(
     id: Int,
     status: BloomStatus,
-    imageData: Data?
+    imageData: Data?,
+    distanceFromSpot: Double?,
+    updateStartTime: Date?
   ) -> Effect<Action> {
-    return .run { [apiClient] send in
+    return .run { [apiClient, analyticsClient] send in
       do {
         let result = try await bloomingClient.updateBloomingState(
           id: id,
           status: status.rawValue
+        )
+
+        // bloom_status_submitted 이벤트 트래킹
+        let completeDuration: Double
+        if let startTime = updateStartTime {
+          completeDuration = Date().timeIntervalSince(startTime)
+        } else {
+          completeDuration = 0
+        }
+        analyticsClient.track(
+          BloomingEvent.statusSubmitted(
+            distanceFromSpot: distanceFromSpot,
+            completeDurationSeconds: completeDuration
+          )
         )
 
         // 이미지 업로드를 독립적인 Task로 실행 (dismiss 후에도 계속 실행)

--- a/Projects/Feature/Blooming/BloomingFeatureInterface/Sources/BloomingUpdateFeature.swift
+++ b/Projects/Feature/Blooming/BloomingFeatureInterface/Sources/BloomingUpdateFeature.swift
@@ -32,15 +32,21 @@ public struct BloomingUpdateFeature {
     public var selectedUIImage: UIImage? = nil
     public var isPhotoPickerPresented: Bool = false
 
-    public init(spotId: Int?, streetName: String) {
+    // Analytics 상태
+    public var distanceFromSpot: Double? = nil
+    public var updateStartTime: Date? = nil
+
+    public init(spotId: Int?, streetName: String, distanceFromSpot: Double? = nil) {
       self.spotId = spotId
       self.streetName = streetName
+      self.distanceFromSpot = distanceFromSpot
     }
   }
   
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
 
+    case onAppear
     case changeStatus
     case initialState
     case sendToastMessage(String)

--- a/Projects/Feature/Blooming/BloomingFeatureInterface/Sources/BloomingUpdateView.swift
+++ b/Projects/Feature/Blooming/BloomingFeatureInterface/Sources/BloomingUpdateView.swift
@@ -64,6 +64,9 @@ public struct BloomingUpdateView: View {
         photosPickerItem = nil
       }
     }
+    .onAppear {
+      store.send(.onAppear)
+    }
   }
   
   @ViewBuilder

--- a/Projects/Feature/Blooming/Project.swift
+++ b/Projects/Feature/Blooming/Project.swift
@@ -12,6 +12,7 @@ import ProjectDescriptionHelpers
 let project = Project.buildFeature(
   for: Feature.Blooming,
   interfaceDependencies: [
-    .Client.Blooming
+    .Client.Blooming,
+    .Client.Analytics
   ]
 )

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeature/Sources/FlowerSpotDetailFeature.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeature/Sources/FlowerSpotDetailFeature.swift
@@ -14,6 +14,7 @@ import FlowerSpotDetailFeatureInterface
 import FlowerSpotClient
 import BloomingClient
 import CacheClient
+import AnalyticsClient
 
 extension FlowerSpotDetailFeature {
   public init() {
@@ -24,6 +25,7 @@ extension FlowerSpotDetailFeature {
     @Dependency(\.flowerSpotClient) var flowerSpotClient
     @Dependency(\.bloomingClient) var bloomingClient
     @Dependency(\.cache) var cache
+    @Dependency(\.analyticsClient) var analyticsClient
 
     func reduce(into state: inout State, action: Action) -> Effect<Action> {
       switch action {
@@ -203,6 +205,16 @@ extension FlowerSpotDetailFeature {
         if let bloomStatus = BloomStatus(rawValue: state.flowerSpotData.bloomingStatus) {
           state.updateMarkerStatus = bloomStatus
         }
+        // spotSelected 이벤트 트래킹
+        analyticsClient.track(
+          MapEvent.spotSelected(
+            spotId: state.flowerSpotData.id,
+            distanceFromSpot: state.distance > 0 ? state.distance : nil,
+            currentBloomStatus: state.flowerSpotData.bloomingStatus,
+            visitCount: state.flowerSpotData.recentlyVisitedCount,
+            entryPoint: state.entryPoint
+          )
+        )
       }
     }
   }

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeature/Sources/FlowerSpotDetailFeature.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeature/Sources/FlowerSpotDetailFeature.swift
@@ -86,6 +86,12 @@ extension FlowerSpotDetailFeature {
 
       case .pushToPhotoGallery:
         state.path.append(.photoGallery)
+        // details_gallery_start 이벤트 트래킹
+        analyticsClient.track(
+          DetailsEvent.galleryStart(
+            distanceFromSpot: state.distance > 0 ? state.distance : nil
+          )
+        )
         return .none
 
       case .popFromPhotoGallery:
@@ -100,6 +106,16 @@ extension FlowerSpotDetailFeature {
           currentIndex: index
         )
         state.isPresentPhotoViewer = true
+        // details_thumbnail_clicked 이벤트 트래킹
+        analyticsClient.track(
+          DetailsEvent.thumbnailClicked(spotPhoto: state.flowerSpotData.imageUrls.count)
+        )
+        // details_viewer_start 이벤트 트래킹
+        analyticsClient.track(
+          DetailsEvent.viewerStart(
+            distanceFromSpot: state.distance > 0 ? state.distance : nil
+          )
+        )
         return .none
 
       case .dismissPhotoViewer:
@@ -193,6 +209,41 @@ extension FlowerSpotDetailFeature {
         checkLoadingComplete(&state)
         return .none
 
+      // MARK: - Analytics
+
+      case .copyAddressTapped:
+        state.copyAddressCount += 1
+        let scrollTimeToReach: Double
+        if let startTime = state.detailsStartTime {
+          scrollTimeToReach = Date().timeIntervalSince(startTime)
+        } else {
+          scrollTimeToReach = 0
+        }
+        // details_copy_address 이벤트 트래킹
+        analyticsClient.track(
+          DetailsEvent.copyAddress(
+            scrollTimeToReach: scrollTimeToReach,
+            copyAddressCount: state.copyAddressCount,
+            copyAddressToUpdate: state.bloomingStatus.totalCount
+          )
+        )
+        return .none
+
+      case .scrollReachedBottom:
+        guard !state.hasTrackedScrollReachBottom else { return .none }
+        state.hasTrackedScrollReachBottom = true
+        let scrollTimeToReach: Double
+        if let startTime = state.detailsStartTime {
+          scrollTimeToReach = Date().timeIntervalSince(startTime)
+        } else {
+          scrollTimeToReach = 0
+        }
+        // details_scroll_reach_bottom 이벤트 트래킹
+        analyticsClient.track(
+          DetailsEvent.scrollReachBottom(scrollTimeToReach: scrollTimeToReach)
+        )
+        return .none
+
       case .delegate, .binding:
         return .none
       }
@@ -213,6 +264,18 @@ extension FlowerSpotDetailFeature {
             currentBloomStatus: state.flowerSpotData.bloomingStatus,
             visitCount: state.flowerSpotData.recentlyVisitedCount,
             entryPoint: state.entryPoint
+          )
+        )
+        // details_start 이벤트 트래킹 및 시작 시간 기록
+        state.detailsStartTime = Date()
+        state.hasTrackedScrollReachBottom = false
+        state.copyAddressCount = 0
+        analyticsClient.track(
+          DetailsEvent.start(
+            spotId: state.flowerSpotData.id,
+            distanceFromSpot: state.distance > 0 ? state.distance : nil,
+            currentBloomStatus: state.flowerSpotData.bloomingStatus,
+            visitCount: state.flowerSpotData.recentlyVisitedCount
           )
         )
       }

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeature/Sources/FlowerSpotDetailFeature.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeature/Sources/FlowerSpotDetailFeature.swift
@@ -42,7 +42,8 @@ extension FlowerSpotDetailFeature {
         if UserDefaultsKeys.isLoggedIn == true {
           let streetName = state.flowerSpotData.streetName
           let id = state.flowerSpotData.id
-          return .send(.presentToBlooming(id: id, streetName: streetName))
+          let distance = state.distance > 0 ? state.distance : nil
+          return .send(.presentToBlooming(id: id, streetName: streetName, distance: distance))
         } else {
           return .send(.showLoginAlert)
         }
@@ -75,8 +76,8 @@ extension FlowerSpotDetailFeature {
         state.isNeedDeletePath = true
         return .send(.delegate(.dismiss))
 
-      case let .presentToBlooming(id, streetName):
-        return .send(.delegate(.presentToBlooming(id: id, streetName: streetName)))
+      case let .presentToBlooming(id, streetName, distance):
+        return .send(.delegate(.presentToBlooming(id: id, streetName: streetName, distance: distance)))
 
       case .showLoginAlert:
         state.isShowLoginAlert = true

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeature/Sources/FlowerSpotDetailFeature.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeature/Sources/FlowerSpotDetailFeature.swift
@@ -250,36 +250,46 @@ extension FlowerSpotDetailFeature {
       }
     }
 
+    /// 로딩 완료 여부 체크 (UI 상태 업데이트만)
     private func checkLoadingComplete(_ state: inout State) {
-      if state.flowerSpotData.id != 0 && state.bloomingStatus.totalCount >= 0 {
-        state.isDetailLoading = false
-        state.isNeedDrawPath = true
-        if let bloomStatus = BloomStatus(rawValue: state.flowerSpotData.bloomingStatus) {
-          state.updateMarkerStatus = bloomStatus
-        }
-        // spotSelected 이벤트 트래킹
-        analyticsClient.track(
-          MapEvent.spotSelected(
-            spotId: state.flowerSpotData.id,
-            distanceFromSpot: state.distance > 0 ? state.distance : nil,
-            currentBloomStatus: state.flowerSpotData.bloomingStatus,
-            visitCount: state.flowerSpotData.recentlyVisitedCount,
-            entryPoint: state.entryPoint
-          )
-        )
-        // details_start 이벤트 트래킹 및 시작 시간 기록
-        state.detailsStartTime = Date()
-        state.hasTrackedScrollReachBottom = false
-        state.copyAddressCount = 0
-        analyticsClient.track(
-          DetailsEvent.start(
-            spotId: state.flowerSpotData.id,
-            distanceFromSpot: state.distance > 0 ? state.distance : nil,
-            currentBloomStatus: state.flowerSpotData.bloomingStatus,
-            visitCount: state.flowerSpotData.recentlyVisitedCount
-          )
-        )
+      // 이미 로딩 완료된 경우 스킵
+      guard state.isDetailLoading else { return }
+      // 모든 데이터가 준비됐는지 확인
+      guard state.flowerSpotData.id != 0 && state.bloomingStatus.totalCount >= 0 else { return }
+
+      state.isDetailLoading = false
+      state.isNeedDrawPath = true
+      if let bloomStatus = BloomStatus(rawValue: state.flowerSpotData.bloomingStatus) {
+        state.updateMarkerStatus = bloomStatus
       }
+      // Analytics 트래킹
+      trackDetailsStart(&state)
+    }
+
+    /// details_start 및 map_spot_selected 이벤트 트래킹
+    private func trackDetailsStart(_ state: inout State) {
+      // spotSelected 이벤트 트래킹
+      analyticsClient.track(
+        MapEvent.spotSelected(
+          spotId: state.flowerSpotData.id,
+          distanceFromSpot: state.distance > 0 ? state.distance : nil,
+          currentBloomStatus: state.flowerSpotData.bloomingStatus,
+          visitCount: state.flowerSpotData.recentlyVisitedCount,
+          entryPoint: state.entryPoint
+        )
+      )
+      // details_start 이벤트 트래킹 및 시작 시간 기록
+      state.detailsStartTime = Date()
+      state.hasTrackedScrollReachBottom = false
+      state.copyAddressCount = 0
+      analyticsClient.track(
+        DetailsEvent.start(
+          spotId: state.flowerSpotData.id,
+          distanceFromSpot: state.distance > 0 ? state.distance : nil,
+          currentBloomStatus: state.flowerSpotData.bloomingStatus,
+          visitCount: state.flowerSpotData.recentlyVisitedCount
+        )
+      )
     }
   }
 }

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailFeature.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailFeature.swift
@@ -12,6 +12,7 @@ import FlowerSpotClient
 import BloomingClient
 import DesignKit
 import Shared
+import AnalyticsClient
 
 @Reducer
 public struct FlowerSpotDetailFeature {
@@ -77,8 +78,12 @@ public struct FlowerSpotDetailFeature {
     /// URL -> Data 매핑 (프리페치된 이미지)
     public var prefetchedImages: [String: Data] = [:]
 
-    public init(userLocation: Coordinate? = nil) {
+    /// 진입 경로 (Analytics 용)
+    public var entryPoint: MapEvent.EntryPoint = .mapPin
+
+    public init(userLocation: Coordinate? = nil, entryPoint: MapEvent.EntryPoint = .mapPin) {
       self.userLocation = userLocation
+      self.entryPoint = entryPoint
     }
   }
 

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailFeature.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailFeature.swift
@@ -81,6 +81,17 @@ public struct FlowerSpotDetailFeature {
     /// 진입 경로 (Analytics 용)
     public var entryPoint: MapEvent.EntryPoint = .mapPin
 
+    // MARK: - Analytics State
+
+    /// 상세 페이지 진입 시간 (스크롤 시간 계산용)
+    public var detailsStartTime: Date? = nil
+
+    /// 주소 복사 횟수 (세션 내)
+    public var copyAddressCount: Int = 0
+
+    /// 하단 도달 이벤트 트래킹 여부
+    public var hasTrackedScrollReachBottom: Bool = false
+
     public init(userLocation: Coordinate? = nil, entryPoint: MapEvent.EntryPoint = .mapPin) {
       self.userLocation = userLocation
       self.entryPoint = entryPoint
@@ -126,6 +137,10 @@ public struct FlowerSpotDetailFeature {
     case prefetchImages
     case imagesPrefetched([String: Data])
     case cacheImage(url: String, data: Data)
+
+    // MARK: - Analytics
+    case copyAddressTapped
+    case scrollReachedBottom
 
     // MARK: - Delegate
     case delegate(Delegate)

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailFeature.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailFeature.swift
@@ -145,12 +145,12 @@ public struct FlowerSpotDetailFeature {
     // MARK: - Delegate
     case delegate(Delegate)
     case dismiss
-    case presentToBlooming(id: Int, streetName: String)
+    case presentToBlooming(id: Int, streetName: String, distance: Double?)
   }
 
   public enum Delegate: Equatable {
     case dismiss
-    case presentToBlooming(id: Int, streetName: String)
+    case presentToBlooming(id: Int, streetName: String, distance: Double?)
     case presentToLogin(id: Int)
     case showOnMap(FlowerSpotEntity)
   }

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailLargeContentView.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailLargeContentView.swift
@@ -245,6 +245,7 @@ public struct FlowerSpotDetailLargeContentView: View {
           }
           .onTapGesture {
             UIPasteboard.general.string = store.flowerSpotData.address
+            store.send(.copyAddressTapped)
             store.send(.showToastView(message: "주소가 복사되었습니다."))
           }
         }
@@ -307,6 +308,9 @@ public struct FlowerSpotDetailLargeContentView: View {
         Text("나무 종류")
           .fontStyle(FontSet.Heading.heading3)
           .foregroundColor(ColorSet.Text.Primary)
+          .onAppear {
+            store.send(.scrollReachedBottom)
+          }
 
         Text(store.flowerSpotData.description)
           .fontStyle(FontSet.Body.body2)

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailView.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailView.swift
@@ -151,6 +151,7 @@ public struct FlowerSpotDetailView: View {
           }
           .onTapGesture {
             UIPasteboard.general.string = store.flowerSpotData.address
+            store.send(.copyAddressTapped)
             store.send(.showToastView(message: "주소가 복사되었습니다."))
           }
         }
@@ -204,7 +205,10 @@ public struct FlowerSpotDetailView: View {
         Text("나무 종류")
           .fontStyle(FontSet.Heading.heading3)
           .foregroundColor(ColorSet.Text.Primary)
-        
+          .onAppear {
+            store.send(.scrollReachedBottom)
+          }
+
         Text(store.flowerSpotData.description)
           .fontStyle(FontSet.Body.body2)
           .foregroundColor(ColorSet.Text.Primary)

--- a/Projects/Feature/FlowerSpotDetail/Project.swift
+++ b/Projects/Feature/FlowerSpotDetail/Project.swift
@@ -15,6 +15,7 @@ let project = Project.buildFeature(
     .Client.FlowerSpot,
     .Client.Blooming,
     .Client.Cache,
+    .Client.Analytics,
     .SPM.NMap
   ]
 )

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
@@ -13,6 +13,7 @@ import MapFeatureInterface
 import FlowerSpotClient
 import FlowerSpotDetailFeatureInterface
 import SearchRegionListFeatureInterface
+import AnalyticsClient
 
 
 extension MapFeature {
@@ -34,6 +35,7 @@ extension MapFeature {
   struct Core: Reducer {
     @Dependency(\.flowerSpotClient) var flowerSpot
     @Dependency(\.openURL) var openURL
+    @Dependency(\.analyticsClient) var analyticsClient
     
     func reduce(into state: inout State, action: Action) -> Effect<Action> {
       switch action {
@@ -44,6 +46,7 @@ extension MapFeature {
         return .none
         
       case .moveToReportURL:
+        analyticsClient.track(MapEvent.reportClicked)
         return .run { send in
           if let url = ExternalURL.report {
             await openURL(url)
@@ -57,6 +60,9 @@ extension MapFeature {
       case let .requestMapBounds(isRequest):
         state.requestMapBound = isRequest
         state.researchButtonEnable = false
+        if isRequest {
+          analyticsClient.track(MapEvent.researchClicked(currentPage: "map"))
+        }
         return .none
         
       case .fetchAllFlowerAddress:

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
@@ -199,8 +199,8 @@ extension MapFeature {
           state.isNeedDeleteMarker = true
           return .none
 
-        case let .presentToBlooming(id, streetName):
-          return .send(.delegate(.presentToBlooming(id: id, streetName: streetName)))
+        case let .presentToBlooming(id, streetName, distance):
+          return .send(.delegate(.presentToBlooming(id: id, streetName: streetName, distance: distance)))
 
         case let .presentToLogin(id):
           return .send(.delegate(.presentToLogin(id: id)))

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/SubFeature/LocationFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/SubFeature/LocationFeature.swift
@@ -13,6 +13,7 @@ import ComposableArchitecture
 import MapFeatureInterface
 import FlowerSpotClient
 import LocationClient
+import AnalyticsClient
 
 extension LocationFeature {
   
@@ -23,6 +24,7 @@ extension LocationFeature {
   struct Core: Reducer {
     @Dependency(\.locationClient) var locationClient
     @Dependency(\.flowerSpotClient) var flowerSpotClient
+    @Dependency(\.analyticsClient) var analyticsClient
     
     public func reduce(into state: inout State, action: Action) -> Effect<Action> {
       switch action {
@@ -40,6 +42,7 @@ extension LocationFeature {
       case let .currentButtonTapped(isTapped):
         state.isCurrentButtonTap = isTapped
         if isTapped {
+          analyticsClient.track(MapEvent.currentLocationClicked(currentPage: "map"))
           return .send(.moveUserLocation)
         }
         return .none
@@ -103,6 +106,7 @@ extension LocationFeature.Core {
         )
         let result = try await flowerSpotClient.fetchAllFlowerPin(query: query)
         if result.itemList.count == 0 {
+          analyticsClient.track(MapEvent.researchFailed)
           await send(.showToastView(message: "이 근방에는 꽃길이 없어요.", buttonLabel: "제보하기"))
         }
         await send(.storeFlowerData(result.itemList))

--- a/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeatureInterface/Sources/MapFeature/MapFeature.swift
@@ -107,7 +107,7 @@ public struct MapFeature {
   public enum Delegate: Equatable {
     case presentToSearch(String?)
     case pushToSetting
-    case presentToBlooming(id: Int, streetName: String)
+    case presentToBlooming(id: Int, streetName: String, distance: Double?)
     case presentToLogin(id: Int)
     case mapDidLoad
   }

--- a/Projects/Feature/Map/Project.swift
+++ b/Projects/Feature/Map/Project.swift
@@ -18,6 +18,7 @@ let project = Project.buildFeature(
     .Client.Blooming,
     .Client.Location,
     .Client.Search,
+    .Client.Analytics,
     .SPM.NMap
   ]
 )

--- a/Projects/Feature/Search/Project.swift
+++ b/Projects/Feature/Search/Project.swift
@@ -13,6 +13,7 @@ let project = Project.buildFeature(
   for: Feature.Search,
   interfaceDependencies: [
     .Client.Search,
-    .Client.FlowerSpot
+    .Client.FlowerSpot,
+    .Client.Analytics
   ]
 )

--- a/Projects/Feature/Search/SearchFeature/Sources/SearchFeature.swift
+++ b/Projects/Feature/Search/SearchFeature/Sources/SearchFeature.swift
@@ -11,7 +11,7 @@ import ComposableArchitecture
 import SearchFeatureInterface
 import SearchClient
 import FlowerSpotClient
-import Shared
+import AnalyticsClient
 
 extension SearchFeature {
   public init() {
@@ -21,6 +21,7 @@ extension SearchFeature {
   struct Core: Reducer {
     @Dependency(\.searchClient) var searchClient
     @Dependency(\.flowerSpotClient) var flowerSpotClient
+    @Dependency(\.analyticsClient) var analyticsClient
 
     func reduce(into state: inout State, action: Action) -> Effect<Action> {
       switch action {
@@ -30,11 +31,16 @@ extension SearchFeature {
           state.showRecentList = true
           return .send(.updateSearchResults(state.recentList))
         } else {
+          // 첫 입력 시 search_input 이벤트 트래킹
+          if state.showRecentList {
+            analyticsClient.track(SearchEvent.input)
+          }
           state.showRecentList = false
           return .send(.searchItem(searchQuery))
         }
 
       case .onAppear:
+        // search_start 이벤트는 fetchRecentResult 완료 후 트래킹
         return .concatenate(
           .send(.configureSearchList),
           .send(.searchBarFocused(true)),
@@ -56,6 +62,15 @@ extension SearchFeature {
 
       case let .updateSearchResults(results):
         state.searchList = results
+        // 검색 결과 없음 트래킹 (최근 검색 목록이 아니고, 결과가 비어있을 때)
+        if !state.showRecentList && results.isEmpty && !state.searchWord.isEmpty {
+          analyticsClient.track(
+            SearchEvent.noResultViewed(
+              keywordLength: state.searchWord.count,
+              resultType: .landmark
+            )
+          )
+        }
         return .none
 
       case .fetchRecentResult:
@@ -63,6 +78,14 @@ extension SearchFeature {
 
       case let .storeRecentResult(item):
         state.recentList = item
+        // search_start 이벤트 트래킹
+        analyticsClient.track(
+          SearchEvent.start(
+            hasRecentSearches: !item.isEmpty,
+            recentSearchesCount: item.count,
+            entryPoint: "map"
+          )
+        )
         return .none
 
       case let .fetchSearchResult(result):
@@ -77,6 +100,14 @@ extension SearchFeature {
         return .none
         
       case let .selectResult(item):
+        // 최근 검색어 클릭 or 자동완성 클릭 트래킹
+        if state.showRecentList {
+          analyticsClient.track(SearchEvent.recentSearchClicked)
+        } else {
+          let resultType: SearchEvent.ResultType = item.searchType == .region ? .region : .landmark
+          analyticsClient.track(SearchEvent.suggestionClicked(resultType: resultType))
+        }
+
         switch item.searchType {
         case .region:
           if let name = item.streetName, let coord = item.coord {

--- a/Projects/Feature/SearchRegionList/SearchRegionListFeature/Sources/SearchRegionListFeature.swift
+++ b/Projects/Feature/SearchRegionList/SearchRegionListFeature/Sources/SearchRegionListFeature.swift
@@ -10,6 +10,7 @@ import SearchRegionListFeatureInterface
 import ComposableArchitecture
 import FlowerSpotClient
 import Shared
+import AnalyticsClient
 
 extension SearchRegionListFeature {
   public init() {
@@ -18,6 +19,7 @@ extension SearchRegionListFeature {
 
   struct Core: Reducer {
     @Dependency(\.flowerSpotClient) var flowerSpotClient
+    @Dependency(\.analyticsClient) var analyticsClient
     
     func reduce(into state: inout State, action: Action) -> Effect<Action> {
       switch action {
@@ -27,9 +29,18 @@ extension SearchRegionListFeature {
       case let .storeFlowerSpots(flowerSpots):
         state.flowerSpots = flowerSpots
         state.isLoading = false
+        // search_result_viewed 이벤트 트래킹
+        analyticsClient.track(
+          SearchEvent.resultViewed(
+            entryPoint: "search",
+            distanceFromRegion: nil,
+            scrollItemCount: flowerSpots.count
+          )
+        )
         return .none
         
       case let .flowerSpotTapped(flowerSpot):
+        analyticsClient.track(SearchEvent.resultClicked)
         return .send(.delegate(.showFlowerSpotDetail(flowerSpot)))
         
       case .delegate: return .none

--- a/Projects/PIDA/Project.swift
+++ b/Projects/PIDA/Project.swift
@@ -19,6 +19,7 @@ let project = Project.buildApp(
     .Client.Push,
     .Client.User,
     .Client.DeepLink,
+    .Client.Analytics,
     .SPM.FirebaseCore,
     .SPM.FirebaseMessaging,
     .Feature.SearchRegionList

--- a/Projects/PIDA/Sources/AppDelegate.swift
+++ b/Projects/PIDA/Sources/AppDelegate.swift
@@ -9,8 +9,10 @@
 import UIKit
 import FirebaseCore
 import FirebaseMessaging
+import ComposableArchitecture
 import Shared
 import DeepLinkClient
+import AnalyticsClient
 
 final class AppDelegate: NSObject, UIApplicationDelegate {
 
@@ -24,6 +26,12 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     // MARK: - Firebase 초기 설정
     FirebaseConfiguration.shared.setLoggerLevel(.min)
     FirebaseApp.configure()
+
+    // MARK: - Mixpanel 초기화
+    if let mixpanelToken = Constant.mixpanel_token {
+      @Dependency(\.analyticsClient) var analyticsClient
+      analyticsClient.initialize(mixpanelToken)
+    }
 
     // MARK: - 푸시 알림 설정
     Messaging.messaging().delegate = self

--- a/Projects/PIDA/Sources/PIDAFeature.swift
+++ b/Projects/PIDA/Sources/PIDAFeature.swift
@@ -35,6 +35,7 @@ import PushClient
 import UserClient
 import LocationClient
 import DeepLinkClient
+import AnalyticsClient
 import Shared
 
 enum Path: Hashable {
@@ -53,6 +54,7 @@ struct PIDAFeature {
   @Dependency(\.pushNotificationClient) var pushNotificationClient
   @Dependency(\.userClient) var userClient
   @Dependency(\.locationClient) var locationClient
+  @Dependency(\.analyticsClient) var analyticsClient
 
   let locationReducer = Reduce(LocationFeature())
   let mapSearchReducer = Reduce(MapSearchFeature())
@@ -425,7 +427,10 @@ extension Reducer where State == PIDAFeature.State, Action == PIDAFeature.Action
 extension PIDAFeature {
   /// 앱 시작 시 푸시 알림 권한 요청 및 구독 초기화
   private func initializeAppLifecycle() -> Effect<Action> {
-    return .run { [pushNotificationClient] send in
+    return .run { [pushNotificationClient, locationClient, analyticsClient] send in
+      // 세션 시작 이벤트 트래킹
+      trackSessionStart(locationClient: locationClient, analyticsClient: analyticsClient)
+
       // 푸시 알림 권한 요청
       let status = await pushNotificationClient.checkAuthorizationStatus()
       if status == .notDetermined {
@@ -436,6 +441,42 @@ extension PIDAFeature {
       // DeepLink 구독 시작
       await send(.subscribeDeepLink)
     }
+  }
+
+  /// 세션 시작 이벤트 트래킹
+  private func trackSessionStart(
+    locationClient: LocationClient,
+    analyticsClient: AnalyticsClient
+  ) {
+    let now = Date()
+
+    // 이전 세션 지속 시간 계산 (초 단위)
+    var sessionDuration: Int? = nil
+    if let startTime = UserDefaultsKeys.sessionStartTime,
+       let endTime = UserDefaultsKeys.lastSessionEndTime {
+      sessionDuration = Int(endTime.timeIntervalSince(startTime))
+    }
+
+    // 이전 세션 종료 후 경과 시간 계산 (초 단위)
+    var sessionPreviousGap: Int? = nil
+    if let lastEndTime = UserDefaultsKeys.lastSessionEndTime {
+      sessionPreviousGap = Int(now.timeIntervalSince(lastEndTime))
+    }
+
+    // 위치 권한 상태 확인
+    let userLocationEnabled = locationClient.checkAuthorizationStatus()
+
+    // 새 세션 시작 시간 저장
+    UserDefaultsKeys.sessionStartTime = now
+
+    // 이벤트 트래킹
+    analyticsClient.track(
+      SessionEvent.start(
+        sessionDuration: sessionDuration,
+        sessionPreviousGap: sessionPreviousGap,
+        userLocationEnabled: userLocationEnabled
+      )
+    )
   }
 
   /// FCM 토큰 수신 구독

--- a/Projects/PIDA/Sources/PIDAFeature.swift
+++ b/Projects/PIDA/Sources/PIDAFeature.swift
@@ -102,7 +102,7 @@ struct PIDAFeature {
 
     case binding(BindingAction<State>)
     case presentSearch(Bool, keyword: String?)
-    case presentBloomingUpdate(Bool, id: Int?, streetName: String)
+    case presentBloomingUpdate(Bool, id: Int?, streetName: String, distance: Double? = nil)
     case presentToLogin(Bool)
     case presentSignUp(Bool)
 
@@ -208,9 +208,9 @@ struct PIDAFeature {
         state.isShowSearch = isShow
         return .none
 
-      case let .presentBloomingUpdate(isPresent, id, streetName):
+      case let .presentBloomingUpdate(isPresent, id, streetName, distance):
         if isPresent {
-          state.blooming = .init(spotId: id, streetName: streetName)
+          state.blooming = .init(spotId: id, streetName: streetName, distanceFromSpot: distance)
         }
         state.isPresentBlooming = isPresent
         return .none
@@ -284,8 +284,8 @@ struct PIDAFeature {
         
       case let .map(.delegate(action)):
         switch action {
-        case let .presentToBlooming(id, streetName):
-          return .send(.presentBloomingUpdate(true, id: id, streetName: streetName))
+        case let .presentToBlooming(id, streetName, distance):
+          return .send(.presentBloomingUpdate(true, id: id, streetName: streetName, distance: distance))
           
         case let .presentToLogin(id):
           state.loginSource = .flowerSpotDetail(spotId: id)

--- a/Projects/PIDA/Sources/PIDAView.swift
+++ b/Projects/PIDA/Sources/PIDAView.swift
@@ -13,6 +13,7 @@ import SearchFeatureInterface
 import SettingFeatureInterface
 import AuthFeatureInterface
 import BloomingFeatureInterface
+import Shared
 
 struct PIDAView: View {
   @Bindable var store: StoreOf<PIDAFeature> = Store(initialState: PIDAFeature.State()) { PIDAFeature()
@@ -73,6 +74,9 @@ struct PIDAView: View {
           store.send(.onAppear)
         }
         .onChange(of: scenePhase) { _, newPhase in
+          if newPhase == .background {
+            UserDefaultsKeys.lastSessionEndTime = Date()
+          }
           store.send(.scenePhaseChanged(newPhase))
         }
     }

--- a/Projects/Shared/Sources/Constant.swift
+++ b/Projects/Shared/Sources/Constant.swift
@@ -11,4 +11,5 @@ import Foundation
 public enum Constant {
   public static let naver_map_client_id = Bundle.main.infoDictionary?["NMCLIENTID"] as? String
   public static let base_url = Bundle.main.infoDictionary?["BASE_URL"] as? String
+  public static let mixpanel_token = Bundle.main.infoDictionary?["MIXPANEL_TOKEN"] as? String
 }

--- a/Projects/Shared/Sources/UserDefault+.swift
+++ b/Projects/Shared/Sources/UserDefault+.swift
@@ -73,4 +73,12 @@ public struct UserDefaultsKeys {
 
   @UserDefault("deviceId", default: nil)
   public static var deviceId: String?
+
+  // MARK: - Session Analytics
+
+  @UserDefault("sessionStartTime", default: nil)
+  public static var sessionStartTime: Date?
+
+  @UserDefault("lastSessionEndTime", default: nil)
+  public static var lastSessionEndTime: Date?
 }

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -33,6 +33,7 @@ let package = Package(
     .package(url: "https://github.com/swiftlang/swift-syntax", exact: "601.0.1"),
     .package(url: "https://github.com/navermaps/SPM-NMapsMap.git", exact: "3.23.0"),
     .package(url: "https://github.com/LottieFiles/dotlottie-ios", exact: "0.8.0"),
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: "12.7.0")
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: "12.7.0"),
+    .package(url: "https://github.com/mixpanel/mixpanel-swift", exact: "5.1.4")
   ]
 )

--- a/Tuist/ProjectDescriptionHelpers/Scheme+.swift
+++ b/Tuist/ProjectDescriptionHelpers/Scheme+.swift
@@ -80,6 +80,7 @@ public enum Scheme {
       "NSLocationWhenInUseUsageDescription": "지도에서 내 위치를 확인하여 길찾기, 네비게이션 기능을 이용하기 위해 권한이 필요합니다.(필수권한)",
       "NMCLIENTID": "$(NM_CLIENT_ID)",
       "BASE_URL": "$(BASE_URL)",
+      "MIXPANEL_TOKEN": "$(MIXPANEL_TOKEN)",
       "ITSAppUsesNonExemptEncryption": false,
       // Firebase
       "FirebaseAppDelegateProxyEnabled": false,

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency/DependencyComponent.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency/DependencyComponent.swift
@@ -34,6 +34,7 @@ extension TargetDependency {
     public static let Location = Self.project(.client(.Location))
     public static let Push = Self.project(.client(.Push))
     public static let DeepLink = Self.project(.client(.DeepLink))
+    public static let Analytics = Self.project(.client(.Analytics))
   }
 }
 
@@ -53,6 +54,7 @@ extension TargetDependency {
     public static let DotLottie = Self.project(.spm(.DotLottie))
     public static let FirebaseCore = Self.project(.spm(.FirebaseCore))
     public static let FirebaseMessaging = Self.project(.spm(.FirebaseMessaging))
+    public static let Mixpanel = Self.project(.spm(.Mixpanel))
   }
 }
 

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency/Modules.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency/Modules.swift
@@ -38,6 +38,7 @@ public enum Client: ModuleRepresentable {
   case Location
   case Push
   case DeepLink
+  case Analytics
 }
 
 public enum SPM: ModuleRepresentable {
@@ -46,4 +47,5 @@ public enum SPM: ModuleRepresentable {
   case DotLottie
   case FirebaseCore
   case FirebaseMessaging
+  case Mixpanel
 }


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #107 

## 🔎 작업 내용
**Mixpanel Analytics 연동**

**AnalyticsClient 구현**
- AnalyticsClient 의존성 모듈 생성 (@DependencyClient 패턴)
- Mixpanel SDK 초기화 및 트래킹 메서드 구현
- 앱 시작 시 Mixpanel 초기화 로직 추가

**이벤트 트래킹 구현 (26개 이벤트)**
|      Category    |      Events     |
|---------------|-------------|
| SessionEvent  | session_start, session_end |
| MapEvent      | map_spot_selected, map_research_clicked, map_report_clicked|
| SearchEvent   | search_bar_clicked, search_submitted|
| DetailsEvent  | details_start, details_thumbnail_clicked, details_gallery_start, details_viewer_start, details_copy_address, details_scroll_reach_bottom |
| BloomingEvent | bloom_update_start, bloom_status_option, bloom_upload_photo, bloom_status_submitted|

**버그 수정**
- map_spot_selected, details_start 이벤트 중복 발생 문제 해결
  - 원인: checkLoadingComplete가 3개 응답(detail, blooming, verifyToday)에서 각각 호출
  - 해결: isDetailLoading 상태를 활용하여 로딩→완료 전환 시에만 트래킹하도록 수정
## 📷 스크린샷

## 🛠️ 기타 공유 내용
**MixPanel 프로젝트 키는 `Debug-Secrets.xcconfig`, `Release-Secrets.xcconfig`에 각 각 따로 추가해야함 (노션에 올려둠)**

- Direct Call 패턴 적용: 각 Feature에서 직접 analyticsClient.track() 호출
- 거리 정보(distanceFromSpot)를 Blooming 화면까지 전달하기 위해 delegate 체인 수정
- 전체 이벤트 중복 트래킹 검사 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking to monitor user interactions and app behavior.
  * Analytics now captures session data, user actions across map, search, blooming updates, and flower spot details views.

* **Chores**
  * Added Mixpanel analytics dependency to support tracking infrastructure.
  * Configured analytics tokens in build settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->