### PR TITLE
Feature/#114 사진 정보에 날짜 데이터 추가

### DIFF
--- a/Projects/Client/FlowerSpot/Sources/DTO/Response/FlowerSpotItemDTO.swift
+++ b/Projects/Client/FlowerSpot/Sources/DTO/Response/FlowerSpotItemDTO.swift
@@ -10,6 +10,25 @@ import Foundation
 import APIClient
 import Shared
 
+struct FlowerSpotImageDTO: Codable {
+  var url: String
+  var createdAt: String?
+
+  func toEntity() -> FlowerSpotImageEntity {
+    var date: Date? = nil
+    if let createdAt = createdAt {
+      let formatter = ISO8601DateFormatter()
+      formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+      date = formatter.date(from: createdAt)
+      if date == nil {
+        formatter.formatOptions = [.withInternetDateTime]
+        date = formatter.date(from: createdAt)
+      }
+    }
+    return FlowerSpotImageEntity(url: url, createdAt: date)
+  }
+}
+
 struct FlowerSpotItemDTO: DTO {
   typealias Entity = FlowerSpotEntity
   var id: Int
@@ -23,6 +42,7 @@ struct FlowerSpotItemDTO: DTO {
   var pinPoint: PointGeomDTO?
   var region: String?
   var imageUrls: [String]?
+  var images: [FlowerSpotImageDTO]?
   var deletedAt: String?
   var previewUrl: String?
 }
@@ -41,7 +61,15 @@ extension FlowerSpotItemDTO {
     let description = self.description ?? "나무 정보 없음"
     let district = self.district ?? ""
     let region = self.region ?? ""
-    let imageUrls = self.imageUrls ?? []
+
+    // images가 있으면 사용, 없으면 imageUrls로 폴백
+    let images: [FlowerSpotImageEntity]
+    if let imagesDTO = self.images, !imagesDTO.isEmpty {
+      images = imagesDTO.map { $0.toEntity() }
+    } else {
+      images = (self.imageUrls ?? []).map { FlowerSpotImageEntity(url: $0) }
+    }
+
     return .init(
       id: self.id,
       address: address,
@@ -53,7 +81,7 @@ extension FlowerSpotItemDTO {
       path: path,
       pinPoint: pinPoint,
       region: region,
-      imageUrls: imageUrls, /*["https://picsum.photos/400/300"]*/
+      images: images,
       previewUrl: previewUrl
     )
   }

--- a/Projects/Client/FlowerSpot/Sources/Entity/FlowerSpotImageEntity.swift
+++ b/Projects/Client/FlowerSpot/Sources/Entity/FlowerSpotImageEntity.swift
@@ -1,0 +1,19 @@
+//
+//  FlowerSpotImageEntity.swift
+//  FlowerSpotClient
+//
+//  Created by 조용인
+//  Copyright © 2026 com.yongin.pida. All rights reserved.
+//
+
+import Foundation
+
+public struct FlowerSpotImageEntity: Equatable, Sendable, Codable {
+  public let url: String
+  public let createdAt: Date?
+
+  public init(url: String, createdAt: Date? = nil) {
+    self.url = url
+    self.createdAt = createdAt
+  }
+}

--- a/Projects/Client/FlowerSpot/Sources/Entity/FlowerSpotListEntity.swift
+++ b/Projects/Client/FlowerSpot/Sources/Entity/FlowerSpotListEntity.swift
@@ -30,8 +30,13 @@ public struct FlowerSpotEntity: Equatable, Sendable, Codable {
   public var path: [Coordinate]
   public var pinPoint: Coordinate
   public var region: String
-  public var imageUrls: [String]
+  public var images: [FlowerSpotImageEntity]
   public var previewUrl: String?
+
+  /// 하위 호환성을 위한 computed property
+  public var imageUrls: [String] {
+    images.map { $0.url }
+  }
 
   public init(
     id: Int,
@@ -44,7 +49,7 @@ public struct FlowerSpotEntity: Equatable, Sendable, Codable {
     path: [Coordinate],
     pinPoint: Coordinate,
     region: String,
-    imageUrls: [String] = [],
+    images: [FlowerSpotImageEntity] = [],
     previewUrl: String? = nil
   ) {
     self.id = id
@@ -58,7 +63,7 @@ public struct FlowerSpotEntity: Equatable, Sendable, Codable {
     self.path = path
     self.pinPoint = pinPoint
     self.region = region
-    self.imageUrls = imageUrls
+    self.images = images
     self.previewUrl = previewUrl
   }
 }

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeature/Sources/FlowerSpotDetailFeature.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeature/Sources/FlowerSpotDetailFeature.swift
@@ -103,13 +103,13 @@ extension FlowerSpotDetailFeature {
 
       case let .presentPhotoViewer(index):
         state.photoViewer = .init(
-          imageUrls: state.flowerSpotData.imageUrls,
+          images: state.flowerSpotData.images,
           currentIndex: index
         )
         state.isPresentPhotoViewer = true
         // details_thumbnail_clicked 이벤트 트래킹
         analyticsClient.track(
-          DetailsEvent.thumbnailClicked(spotPhoto: state.flowerSpotData.imageUrls.count)
+          DetailsEvent.thumbnailClicked(spotPhoto: state.flowerSpotData.images.count)
         )
         // details_viewer_start 이벤트 트래킹
         analyticsClient.track(
@@ -137,7 +137,7 @@ extension FlowerSpotDetailFeature {
 
       case .photoViewerNextTapped:
         guard var viewer = state.photoViewer else { return .none }
-        if viewer.currentIndex < viewer.imageUrls.count - 1 {
+        if viewer.currentIndex < viewer.images.count - 1 {
           viewer.currentIndex += 1
           state.photoViewer = viewer
         }

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailFeature.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailFeature.swift
@@ -31,13 +31,13 @@ public struct FlowerSpotDetailFeature {
   // MARK: - PhotoViewer State
 
   public struct PhotoViewerState: Equatable {
-    public var imageUrls: [String]
+    public var images: [FlowerSpotImageEntity]
     public var currentIndex: Int
     public var scale: CGFloat
     public var isUIHidden: Bool
 
-    public init(imageUrls: [String], currentIndex: Int) {
-      self.imageUrls = imageUrls
+    public init(images: [FlowerSpotImageEntity], currentIndex: Int) {
+      self.images = images
       self.currentIndex = currentIndex
       self.scale = 1.0
       self.isUIHidden = false

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailLargeContentView.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailLargeContentView.swift
@@ -203,7 +203,7 @@ public struct FlowerSpotDetailLargeContentView: View {
 
       // Image Gallery
       FlowerSpotImageGalleryView(
-        imageUrls: store.flowerSpotData.imageUrls,
+        images: store.flowerSpotData.images,
         prefetchedImages: store.prefetchedImages,
         onImageTapped: { index in
           store.send(.presentPhotoViewer(index: index))

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailLargeContentView.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailLargeContentView.swift
@@ -58,7 +58,7 @@ public struct FlowerSpotDetailLargeContentView: View {
         switch path {
         case .photoGallery:
           PhotoGalleryView(
-            imageUrls: store.flowerSpotData.imageUrls,
+            images: store.flowerSpotData.images,
             prefetchedImages: store.prefetchedImages,
             title: store.flowerSpotData.streetName,
             onImageTapped: { index in
@@ -79,7 +79,7 @@ public struct FlowerSpotDetailLargeContentView: View {
     }) {
       if let viewer = store.photoViewer {
         PhotoViewerView(
-          imageUrls: viewer.imageUrls,
+          images: viewer.images,
           prefetchedImages: store.prefetchedImages,
           currentIndex: viewer.currentIndex,
           onDismiss: {

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotImageGalleryView.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotImageGalleryView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import DesignKit
+import FlowerSpotClient
 
 /// 확장 바텀시트에서 이미지를 표시하는 갤러리 뷰
 /// - 0장: 표시 안함
@@ -15,7 +16,7 @@ import DesignKit
 /// - 2장: 가로 나란히 (spacing 12)
 /// - 3장+: 수평 스크롤 (160x160) + 더보기 버튼
 public struct FlowerSpotImageGalleryView: View {
-  private let imageUrls: [String]
+  private let images: [FlowerSpotImageEntity]
   private let prefetchedImages: [String: Data]
   private let onImageTapped: ((Int) -> Void)?
   private let onMoreTapped: (() -> Void)?
@@ -25,13 +26,13 @@ public struct FlowerSpotImageGalleryView: View {
   private let spacing: CGFloat = 12
 
   public init(
-    imageUrls: [String],
+    images: [FlowerSpotImageEntity],
     prefetchedImages: [String: Data] = [:],
     onImageTapped: ((Int) -> Void)? = nil,
     onMoreTapped: (() -> Void)? = nil,
     onImageLoaded: ((String, Data) -> Void)? = nil
   ) {
-    self.imageUrls = imageUrls
+    self.images = images
     self.prefetchedImages = prefetchedImages
     self.onImageTapped = onImageTapped
     self.onMoreTapped = onMoreTapped
@@ -40,7 +41,7 @@ public struct FlowerSpotImageGalleryView: View {
 
   public var body: some View {
     Group {
-      switch imageUrls.count {
+      switch images.count {
       case 0:
         EmptyView()
       case 1:
@@ -57,12 +58,12 @@ public struct FlowerSpotImageGalleryView: View {
 
   @ViewBuilder
   private var singleImageView: some View {
-    let url = imageUrls[0]
+    let image = images[0]
     RemoteImageView(
-      imageData: prefetchedImages[url],
-      fallbackUrlString: url,
+      imageData: prefetchedImages[image.url],
+      fallbackUrlString: image.url,
       onTap: { onImageTapped?(0) },
-      onImageLoaded: { data in onImageLoaded?(url, data) }
+      onImageLoaded: { data in onImageLoaded?(image.url, data) }
     )
     .frame(height: imageHeight)
     .frame(maxWidth: .infinity)
@@ -78,12 +79,12 @@ public struct FlowerSpotImageGalleryView: View {
       let imageWidth = (geometry.size.width - spacing) / 2
       HStack(spacing: spacing) {
         ForEach(0..<2, id: \.self) { index in
-          let url = imageUrls[index]
+          let image = images[index]
           RemoteImageView(
-            imageData: prefetchedImages[url],
-            fallbackUrlString: url,
+            imageData: prefetchedImages[image.url],
+            fallbackUrlString: image.url,
             onTap: { onImageTapped?(index) },
-            onImageLoaded: { data in onImageLoaded?(url, data) }
+            onImageLoaded: { data in onImageLoaded?(image.url, data) }
           )
           .frame(width: imageWidth, height: imageHeight)
           .clipped()
@@ -100,13 +101,13 @@ public struct FlowerSpotImageGalleryView: View {
   private var multipleImagesView: some View {
     ScrollView(.horizontal, showsIndicators: false) {
       HStack(spacing: spacing) {
-        ForEach(0..<min(3, imageUrls.count), id: \.self) { index in
-          let url = imageUrls[index]
+        ForEach(0..<min(3, images.count), id: \.self) { index in
+          let image = images[index]
           RemoteImageView(
-            imageData: prefetchedImages[url],
-            fallbackUrlString: url,
+            imageData: prefetchedImages[image.url],
+            fallbackUrlString: image.url,
             onTap: { onImageTapped?(index) },
-            onImageLoaded: { data in onImageLoaded?(url, data) }
+            onImageLoaded: { data in onImageLoaded?(image.url, data) }
           )
           .frame(width: imageHeight, height: imageHeight)
           .clipped()

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/PhotoGalleryView.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/PhotoGalleryView.swift
@@ -75,8 +75,7 @@ public struct PhotoGalleryView: View {
       let itemWidth = (geometry.size.width - 16 * 2 - 12) / 2
       ScrollView {
         LazyVGrid(columns: columns, spacing: 12) {
-          ForEach(0..<images.count, id: \.self) { index in
-            let image = images[index]
+          ForEach(Array(images.enumerated()), id: \.offset) { index, image in
             ZStack(alignment: .bottomTrailing) {
               RemoteImageView(
                 imageData: prefetchedImages[image.url],
@@ -88,11 +87,30 @@ public struct PhotoGalleryView: View {
               .clipped()
 
               if let dateText = image.createdAt?.photoDateText() {
-                Text(dateText)
-                  .fontStyle(FontSet.Caption.caption1)
-                  .foregroundColor(ColorSet.Text.Inverse)
+                // 하단 그라디언트 오버레이 + 텍스트
+                VStack {
+                  Spacer()
+                  HStack {
+                    Spacer()
+                    Text(dateText)
+                      .fontStyle(FontSet.Caption.caption1)
+                      .foregroundColor(ColorSet.Text.Inverse)
+                  }
+                  .padding(.top, .Number8)
+                  .padding(.bottom, .Number8)
+                  .padding(.leading, .Number12)
                   .padding(.trailing, .Number12)
-                  .padding(.bottom, .Number4)
+                  .background(
+                    LinearGradient(
+                      gradient: Gradient(colors: [
+                        Color(hex: 0x121212).opacity(0),
+                        Color(hex: 0x121212).opacity(0.4)
+                      ]),
+                      startPoint: .top,
+                      endPoint: .bottom
+                    )
+                  )
+                }
               }
             }
             .cornerRadius(16)
@@ -103,4 +121,50 @@ public struct PhotoGalleryView: View {
       }
     }
   }
+}
+
+// MARK: - Preview
+
+#Preview {
+  let calendar = Calendar.current
+  let now = Date()
+
+  // 더미 이미지 데이터 (다양한 날짜)
+  let dummyImages: [FlowerSpotImageEntity] = [
+    // 당일 (표시 안 함)
+    FlowerSpotImageEntity(
+      url: "https://picsum.photos/400/400?random=1",
+      createdAt: now
+    ),
+    // 3일 전
+    FlowerSpotImageEntity(
+      url: "https://picsum.photos/400/400?random=2",
+      createdAt: calendar.date(byAdding: .day, value: -3, to: now)
+    ),
+    // 7일 전
+    FlowerSpotImageEntity(
+      url: "https://picsum.photos/400/400?random=3",
+      createdAt: calendar.date(byAdding: .day, value: -7, to: now)
+    ),
+    // 15일 전 (같은 해 → "M월 D일")
+    FlowerSpotImageEntity(
+      url: "https://picsum.photos/400/400?random=4",
+      createdAt: calendar.date(byAdding: .day, value: -15, to: now)
+    ),
+    // 작년 (다른 해 → "YYYY년 M월 D일")
+    FlowerSpotImageEntity(
+      url: "https://picsum.photos/400/400?random=5",
+      createdAt: calendar.date(byAdding: .year, value: -1, to: now)
+    ),
+    // 날짜 없음 (표시 안 함)
+    FlowerSpotImageEntity(
+      url: "https://picsum.photos/400/400?random=6",
+      createdAt: nil
+    )
+  ]
+
+  return PhotoGalleryView(
+    images: dummyImages,
+    title: "여의도 윤중로"
+  )
 }

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/PhotoGalleryView.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/PhotoGalleryView.swift
@@ -8,10 +8,12 @@
 
 import SwiftUI
 import DesignKit
+import FlowerSpotClient
+import Shared
 
 /// 이미지 갤러리 화면 (2열 그리드)
 public struct PhotoGalleryView: View {
-  private let imageUrls: [String]
+  private let images: [FlowerSpotImageEntity]
   private let prefetchedImages: [String: Data]
   private let title: String
   private let onImageTapped: ((Int) -> Void)?
@@ -24,14 +26,14 @@ public struct PhotoGalleryView: View {
   ]
 
   public init(
-    imageUrls: [String],
+    images: [FlowerSpotImageEntity],
     prefetchedImages: [String: Data] = [:],
     title: String,
     onImageTapped: ((Int) -> Void)? = nil,
     onBackTapped: (() -> Void)? = nil,
     onImageLoaded: ((String, Data) -> Void)? = nil
   ) {
-    self.imageUrls = imageUrls
+    self.images = images
     self.prefetchedImages = prefetchedImages
     self.title = title
     self.onImageTapped = onImageTapped
@@ -73,16 +75,26 @@ public struct PhotoGalleryView: View {
       let itemWidth = (geometry.size.width - 16 * 2 - 12) / 2
       ScrollView {
         LazyVGrid(columns: columns, spacing: 12) {
-          ForEach(0..<imageUrls.count, id: \.self) { index in
-            let url = imageUrls[index]
-            RemoteImageView(
-              imageData: prefetchedImages[url],
-              fallbackUrlString: url,
-              onTap: { onImageTapped?(index) },
-              onImageLoaded: { data in onImageLoaded?(url, data) }
-            )
-            .frame(width: itemWidth, height: itemWidth)
-            .clipped()
+          ForEach(0..<images.count, id: \.self) { index in
+            let image = images[index]
+            ZStack(alignment: .bottomTrailing) {
+              RemoteImageView(
+                imageData: prefetchedImages[image.url],
+                fallbackUrlString: image.url,
+                onTap: { onImageTapped?(index) },
+                onImageLoaded: { data in onImageLoaded?(image.url, data) }
+              )
+              .frame(width: itemWidth, height: itemWidth)
+              .clipped()
+
+              if let dateText = image.createdAt?.photoDateText() {
+                Text(dateText)
+                  .fontStyle(FontSet.Caption.caption1)
+                  .foregroundColor(ColorSet.Text.Inverse)
+                  .padding(.trailing, .Number12)
+                  .padding(.bottom, .Number4)
+              }
+            }
             .cornerRadius(16)
           }
         }

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/PhotoViewerView.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/PhotoViewerView.swift
@@ -8,10 +8,12 @@
 
 import SwiftUI
 import DesignKit
+import FlowerSpotClient
+import Shared
 
 /// 이미지 상세 뷰어 (전체화면, Pinch 확대)
 public struct PhotoViewerView: View {
-  private let imageUrls: [String]
+  private let images: [FlowerSpotImageEntity]
   private let prefetchedImages: [String: Data]
   private let currentIndex: Int
   private let onDismiss: (() -> Void)?
@@ -34,7 +36,7 @@ public struct PhotoViewerView: View {
   private let maxScale: CGFloat = 10.0
 
   public init(
-    imageUrls: [String],
+    images: [FlowerSpotImageEntity],
     prefetchedImages: [String: Data] = [:],
     currentIndex: Int,
     onDismiss: (() -> Void)? = nil,
@@ -42,7 +44,7 @@ public struct PhotoViewerView: View {
     onNextTapped: (() -> Void)? = nil,
     onImageLoaded: ((String, Data) -> Void)? = nil
   ) {
-    self.imageUrls = imageUrls
+    self.images = images
     self.prefetchedImages = prefetchedImages
     self.currentIndex = currentIndex
     self.onDismiss = onDismiss
@@ -73,12 +75,12 @@ public struct PhotoViewerView: View {
         }
 
       // 이미지
-      if currentIndex < imageUrls.count {
-        let url = imageUrls[currentIndex]
+      if currentIndex < images.count {
+        let image = images[currentIndex]
         RemoteImageView(
-          imageData: prefetchedImages[url],
-          fallbackUrlString: url,
-          onImageLoaded: { data in onImageLoaded?(url, data) }
+          imageData: prefetchedImages[image.url],
+          fallbackUrlString: image.url,
+          onImageLoaded: { data in onImageLoaded?(image.url, data) }
         )
         .placeholderStyle(.dark)
         .aspectRatio(contentMode: .fit)
@@ -191,10 +193,19 @@ public struct PhotoViewerView: View {
 
   // MARK: - Top Bar
 
+  private var topBarTitle: String {
+    let indexText = "\(currentIndex + 1)/\(images.count)"
+    if currentIndex < images.count,
+       let dateText = images[currentIndex].createdAt?.photoDateText() {
+      return "\(indexText) · \(dateText)"
+    }
+    return indexText
+  }
+
   @ViewBuilder
   private var topBar: some View {
     NavigationBar(
-      title: "\(currentIndex + 1)/\(imageUrls.count)",
+      title: topBarTitle,
       closeContent: {
         TouchArea(image: .close)
           .action {
@@ -225,7 +236,7 @@ public struct PhotoViewerView: View {
       Spacer()
 
       // 오른쪽 쉐브론 (마지막 이미지면 숨김)
-      if currentIndex < imageUrls.count - 1 {
+      if currentIndex < images.count - 1 {
         chevronButton(direction: .right) {
           onNextTapped?()
         }

--- a/Projects/Shared/Sources/Extensions/Color+.swift
+++ b/Projects/Shared/Sources/Extensions/Color+.swift
@@ -1,0 +1,21 @@
+//
+//  Color+.swift
+//  Shared
+//
+//  Created by 조용인
+//  Copyright © 2026 com.yongin.pida. All rights reserved.
+//
+
+import SwiftUI
+
+public extension Color {
+  /// hex 값으로 Color 생성
+  /// - Parameter hex: 0xRRGGBB 형식의 hex 값
+  init(hex: UInt) {
+    self.init(
+      red: Double((hex >> 16) & 0xFF) / 255.0,
+      green: Double((hex >> 8) & 0xFF) / 255.0,
+      blue: Double(hex & 0xFF) / 255.0
+    )
+  }
+}

--- a/Projects/Shared/Sources/Extensions/Date+.swift
+++ b/Projects/Shared/Sources/Extensions/Date+.swift
@@ -43,11 +43,42 @@ public extension Date {
     let startOfReference = calendar.startOfDay(for: referenceDate)
     let components = calendar.dateComponents([.day], from: startOfReference, to: startOfSelf)
     let dayDiff = components.day ?? 0
-    
+
     switch dayDiff {
     case 0: return "오늘"
     case let x where x < 0: return "\(-x)일 전"
     default: return "\(dayDiff)일 후"
+    }
+  }
+
+  /// 사진 업로드 날짜 표기
+  /// - 당일: nil
+  /// - 1~10일 전: "N일 전"
+  /// - 11일 이상 (같은 해): "M월 D일"
+  /// - 11일 이상 (다른 해): "YYYY년 M월 D일"
+  func photoDateText(from referenceDate: Date = Date()) -> String? {
+    let calendar = Calendar.current
+    let startOfSelf = calendar.startOfDay(for: self)
+    let startOfReference = calendar.startOfDay(for: referenceDate)
+    let components = calendar.dateComponents([.day], from: startOfSelf, to: startOfReference)
+    let dayDiff = components.day ?? 0
+
+    switch dayDiff {
+    case 0:
+      return nil
+    case 1...10:
+      return "\(dayDiff)일 전"
+    default:
+      let selfYear = calendar.component(.year, from: self)
+      let referenceYear = calendar.component(.year, from: referenceDate)
+      let month = calendar.component(.month, from: self)
+      let day = calendar.component(.day, from: self)
+
+      if selfYear == referenceYear {
+        return "\(month)월 \(day)일"
+      } else {
+        return "\(selfYear)년 \(month)월 \(day)일"
+      }
     }
   }
 }


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #114 

## 🔎 작업 내용
- 사진 업로드 시기별 날짜 표기 기능 구현
- FlowerSpotImageEntity 모델 추가 (url, createdAt 필드)
- photoDateText() 메서드 추가 (날짜 표기 규칙 적용)
- PhotoGalleryView 이미지 셀 우측 하단에 날짜 오버레이 추가
- PhotoViewerView TopBar에 "1/5 · 3일 전" 형식으로 날짜 표시
- API 응답 형식 변경 대응: imageUrls: [String] → images: [{url, createdAt}]

### 날짜 표기 규칙
| 조건            | 표기            |
|---------------|---------------|
| 당일            | 표시 안 함        |
| 1~10일 전       | "N일 전"        |
| 11일 이상 (같은 해) | "M월 D일"       |
| 11일 이상 (다른 해) | "YYYY년 M월 D일" |

## 📷 스크린샷

## 🛠️ 기타 공유 내용
- 기존 imageUrls API 응답에 대한 하위 호환성 유지 (images가 없으면 imageUrls로 폴백)
- 서버 API 수정 후 바로 적용 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Photo gallery and viewer now show image creation dates (overlay and top-bar) when available.
* **Improvements**
  * Image data upgraded to carry structured info (URL + optional creation date) for consistent display and loading.
  * Views and navigation updated to use the richer image objects while preserving URL-based accessors for compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->