### PR TITLE
qa: 1차 QA 반영

### DIFF
--- a/Projects/DesignKit/Sources/Component/BottomSheet/BottomSheet.swift
+++ b/Projects/DesignKit/Sources/Component/BottomSheet/BottomSheet.swift
@@ -52,7 +52,7 @@ public struct CherryBlossomBottomSheet<SmallContent: View, LargeContent: View>: 
   ) {
     self.minHeight = minHeight
     self.maxHeight = maxHeight
-    self.midHeight = midHeight ?? (minHeight + maxHeight) / 2
+    self.midHeight = midHeight ?? minHeight + (maxHeight - minHeight) / 3
     self.smallContent = smallContent
     self.largeContent = largeContent
     self.onDismiss = onDismiss
@@ -140,6 +140,12 @@ public struct CherryBlossomBottomSheet<SmallContent: View, LargeContent: View>: 
       }
       .scrollDisabled(true)
       .frame(height: currentHeight - .Number20)
+      .contentShape(Rectangle())
+      .onTapGesture {
+        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+          currentHeight = maxHeight
+        }
+      }
     } else {
       largeContent()
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Projects/DesignKit/Sources/Component/BottomSheet/BottomSheet.swift
+++ b/Projects/DesignKit/Sources/Component/BottomSheet/BottomSheet.swift
@@ -98,7 +98,7 @@ public struct CherryBlossomBottomSheet<SmallContent: View, LargeContent: View>: 
     .background(ColorSet.Background.Primary)
     .cornerRadius(.Number16, corners: [.topLeft, .topRight])
     .shadow(color: .black.opacity(0.1), radius: 10, x: 0, y: -5)
-    .gesture(shouldEnableDrag ? dragGesture() : nil)
+    .simultaneousGesture(shouldEnableDrag ? dragGesture() : nil)
   }
 
   /// 드래그 활성화 여부 결정

--- a/Projects/DesignKit/Sources/Component/BottomSheet/BottomSheet.swift
+++ b/Projects/DesignKit/Sources/Component/BottomSheet/BottomSheet.swift
@@ -11,37 +11,37 @@ import SwiftUI
 // MARK: - New CherryBlossomBottomSheet (Generic)
 
 public struct CherryBlossomBottomSheet<SmallContent: View, LargeContent: View>: View {
-
+  
   // MARK: - Properties
-
+  
   /// 바텀시트 최소 높이 (축소 상태)
   let minHeight: CGFloat
   /// 바텀시트 최대 높이 (확장 상태)
   let maxHeight: CGFloat
   /// 콘텐츠 전환 기준 높이
   let midHeight: CGFloat
-
+  
   /// 축소 상태에서 보여줄 콘텐츠
   let smallContent: () -> SmallContent
   /// 확장 상태에서 보여줄 콘텐츠
   let largeContent: () -> LargeContent
   /// dismiss 시 호출되는 콜백
   let onDismiss: (() -> Void)?
-
+  
   // MARK: - Internal State (View 전용)
-
+  
   @State private var currentHeight: CGFloat
   @State private var isDragging: Bool = false
   @State private var initialHeight: CGFloat = 0
-
+  
   /// 외부에서 드래그 가능 여부를 제어 (스크롤 ↔ 드래그 충돌 제어용)
   @Binding private var isDragEnabled: Bool
   /// 외부에서 확장/축소 상태를 제어
   @Binding private var isExpanded: Bool
-
+  
   // MARK: - Init
   public init(
-    minHeight: CGFloat = 140,
+    minHeight: CGFloat = 166,
     maxHeight: CGFloat = UIScreen.main.bounds.height,
     midHeight: CGFloat? = nil,
     isDragEnabled: Binding<Bool>,
@@ -60,9 +60,9 @@ public struct CherryBlossomBottomSheet<SmallContent: View, LargeContent: View>: 
     self._isDragEnabled = isDragEnabled
     self._isExpanded = isExpanded
   }
-
+  
   // MARK: - Body
-
+  
   public var body: some View {
     VStack {
       Spacer()
@@ -72,6 +72,7 @@ public struct CherryBlossomBottomSheet<SmallContent: View, LargeContent: View>: 
       sheetView
     }
     .ignoresSafeArea()
+    .padding(.bottom, UIApplication.shared.safeAreaBottomInset)
     .onChange(of: isExpanded) { _, newValue in
       withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
         currentHeight = newValue ? maxHeight : minHeight
@@ -85,9 +86,9 @@ public struct CherryBlossomBottomSheet<SmallContent: View, LargeContent: View>: 
       }
     }
   }
-
+  
   // MARK: - Sheet View
-
+  
   private var sheetView: some View {
     VStack(spacing: .Number0) {
       handleIndicator
@@ -100,23 +101,23 @@ public struct CherryBlossomBottomSheet<SmallContent: View, LargeContent: View>: 
     .shadow(color: .black.opacity(0.1), radius: 10, x: 0, y: -5)
     .simultaneousGesture(shouldEnableDrag ? dragGesture() : nil)
   }
-
+  
   /// 드래그 활성화 여부 결정
   /// - 축소 상태에서는 스크롤이 없으므로 항상 드래그 활성화
   /// - 확장 상태에서는 외부 바인딩(isDragEnabled)에 따라 결정
   private var shouldEnableDrag: Bool {
     currentHeight < midHeight ? true : isDragEnabled
   }
-
+  
   // MARK: - Handle Indicator
-
+  
   private var handleIndicator: some View {
     VStack {
       Spacer()
       RoundedRectangle(cornerRadius: .Number2)
         .fill(ColorSet.Gray._200)
         .frame(width: .Number80, height: .Number4)
-        .padding(.bottom, .Number4)
+        .padding(.bottom, .Number2)
     }
     .frame(maxWidth: .infinity)
     .contentShape(Rectangle())
@@ -128,9 +129,9 @@ public struct CherryBlossomBottomSheet<SmallContent: View, LargeContent: View>: 
       }
     }
   }
-
+  
   // MARK: - Content View
-
+  
   @ViewBuilder
   private var contentView: some View {
     if currentHeight < midHeight {
@@ -151,9 +152,9 @@ public struct CherryBlossomBottomSheet<SmallContent: View, LargeContent: View>: 
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
   }
-
+  
   // MARK: - Drag Gesture
-
+  
   private func dragGesture() -> some Gesture {
     DragGesture(coordinateSpace: .global)
       .onChanged { value in
@@ -161,7 +162,7 @@ public struct CherryBlossomBottomSheet<SmallContent: View, LargeContent: View>: 
           isDragging = true
           initialHeight = currentHeight
         }
-
+        
         let translation = value.translation.height
         if translation > 0 {
           // 아래로 드래그 → 높이 감소
@@ -173,16 +174,16 @@ public struct CherryBlossomBottomSheet<SmallContent: View, LargeContent: View>: 
       }
       .onEnded { value in
         isDragging = false
-
+        
         // 드래그 속도 계산
         let velocity = value.predictedEndLocation.y - value.location.y
-
+        
         // 빠른 아래 스와이프 → dismiss
         if velocity > 450 && currentHeight <= minHeight + 50 {
           onDismiss?()
           return
         }
-
+        
         // 빠른 스와이프 감지 (threshold: 450)
         if abs(velocity) > 450 {
           withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {

--- a/Projects/DesignKit/Sources/Component/ScrollView/ScrollViewConfigurator.swift
+++ b/Projects/DesignKit/Sources/Component/ScrollView/ScrollViewConfigurator.swift
@@ -1,0 +1,45 @@
+//
+//  ScrollViewConfigurator.swift
+//  DesignKit
+//
+//  Created by 조용인
+//
+
+import SwiftUI
+
+/// UIScrollView의 속성을 제어하기 위한 UIViewRepresentable.
+/// ScrollView 콘텐츠의 `.background()`에 배치하여 부모 UIScrollView를 찾아 설정합니다.
+///
+/// ```swift
+/// ScrollView {
+///   content
+///     .background(ScrollViewConfigurator(bounces: false))
+/// }
+/// ```
+public struct ScrollViewConfigurator: UIViewRepresentable {
+  public var bounces: Bool
+
+  public init(bounces: Bool) {
+    self.bounces = bounces
+  }
+
+  public func makeUIView(context: Context) -> UIView {
+    let view = UIView(frame: .zero)
+    view.isHidden = true
+    view.isUserInteractionEnabled = false
+    return view
+  }
+
+  public func updateUIView(_ uiView: UIView, context: Context) {
+    DispatchQueue.main.async {
+      var current: UIView? = uiView
+      while let view = current {
+        if let scrollView = view as? UIScrollView {
+          scrollView.bounces = bounces
+          break
+        }
+        current = view.superview
+      }
+    }
+  }
+}

--- a/Projects/DesignKit/Sources/Resource+/Font+.swift
+++ b/Projects/DesignKit/Sources/Resource+/Font+.swift
@@ -13,7 +13,7 @@ extension DesignKitFontFamily {
   public struct FontSet: Sendable {
     public struct Heading: Sendable {
       public static let heading1 = FontInfo(font: Pretendard.semiBold, size: 24, lineHeight: 1.4)
-      public static let heading2 = FontInfo(font: Pretendard.semiBold, size: 20, lineHeight: 1.4)
+      public static let heading2 = FontInfo(font: Pretendard.semiBold, size: 22, lineHeight: 1.4)
       public static let heading3 = FontInfo(font: Pretendard.semiBold, size: 18, lineHeight: 1.4)
       public static let heading4 = FontInfo(font: Pretendard.semiBold, size: 16, lineHeight: 1.4)
     }

--- a/Projects/DesignKit/Sources/Resource+/Size+.swift
+++ b/Projects/DesignKit/Sources/Resource+/Size+.swift
@@ -30,6 +30,7 @@ public extension CGFloat {
   static let Number54: CGFloat = 54
   static let Number56: CGFloat = 56
   static let Number64: CGFloat = 64
+  static let Number66: CGFloat = 66
   static let Number80: CGFloat = 80
   static let Number100: CGFloat = 100
   static let Number120: CGFloat = 120

--- a/Projects/Feature/Blooming/BloomingFeatureInterface/Sources/BloomingUpdateView.swift
+++ b/Projects/Feature/Blooming/BloomingFeatureInterface/Sources/BloomingUpdateView.swift
@@ -159,16 +159,19 @@ public struct BloomingUpdateView: View {
       VStack(alignment: .center, spacing: .Number0) {
         Text("오늘 방문한")
           .foregroundStyle(ColorSet.Text.Primary)
+          .fontStyle(FontSet.Heading.heading2)
         HStack(spacing: .Number0) {
           Text(store.streetName)
             .foregroundStyle(ColorSet.Text.Accent)
+            .fontStyle(FontSet.Heading.heading2)
           Text("의")
             .foregroundStyle(ColorSet.Text.Primary)
+            .fontStyle(FontSet.Heading.heading2)
         }
         Text("개화상태는 어땠나요?")
           .foregroundStyle(ColorSet.Text.Primary)
+          .fontStyle(FontSet.Heading.heading2)
       }
-      .fontStyle(FontSet.Heading.heading2)
     }
     
   }

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeature/Sources/FlowerSpotDetailFeature.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeature/Sources/FlowerSpotDetailFeature.swift
@@ -188,16 +188,20 @@ extension FlowerSpotDetailFeature {
           state.distance = .zero
         }
         checkLoadingComplete(&state)
-        // 이미지 프리페치 시작
+        // 이미지 프리페치 시작 + 부모에게 최신 데이터 전달
         if shouldUpdateMap {
           // 딥링크 진입: 지도 위치 이동 + 마커 표시
           return .concatenate(
             .send(.prefetchImages),
-            .send(.delegate(.showOnMap(item)))
+            .send(.delegate(.showOnMap(item))),
+            .send(.delegate(.didUpdateFlowerSpot(item)))
           )
         } else {
-          // 마커 탭/검색: 프리페치만
-          return .send(.prefetchImages)
+          // 마커 탭/검색: 프리페치 + 부모 동기화
+          return .concatenate(
+            .send(.prefetchImages),
+            .send(.delegate(.didUpdateFlowerSpot(item)))
+          )
         }
 
       case let .bloomingResponse(item):

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeature/Sources/FlowerSpotDetailFeature.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeature/Sources/FlowerSpotDetailFeature.swift
@@ -86,7 +86,7 @@ extension FlowerSpotDetailFeature {
       // MARK: - Navigation (PhotoGallery)
 
       case .pushToPhotoGallery:
-        state.path.append(.photoGallery)
+        state.isPresentPhotoGallery = true
         // details_gallery_start 이벤트 트래킹
         analyticsClient.track(
           DetailsEvent.galleryStart(
@@ -96,7 +96,7 @@ extension FlowerSpotDetailFeature {
         return .none
 
       case .popFromPhotoGallery:
-        state.path.removeLast()
+        state.isPresentPhotoGallery = false
         return .none
 
       // MARK: - Presentation (PhotoViewer)

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailFeature.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailFeature.swift
@@ -22,12 +22,6 @@ public struct FlowerSpotDetailFeature {
     self.reducer = reducer
   }
 
-  // MARK: - Path (내부 NavigationStack용)
-
-  public enum Path: Hashable {
-    case photoGallery
-  }
-
   // MARK: - PhotoViewer State
 
   public struct PhotoViewerState: Equatable {
@@ -69,7 +63,7 @@ public struct FlowerSpotDetailFeature {
 
     // MARK: - Navigation State
 
-    public var path: [Path] = []
+    public var isPresentPhotoGallery: Bool = false
     public var photoViewer: PhotoViewerState? = nil
     public var isPresentPhotoViewer: Bool = false
 

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailFeature.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailFeature.swift
@@ -147,6 +147,7 @@ public struct FlowerSpotDetailFeature {
     case presentToBlooming(id: Int, streetName: String, distance: Double?)
     case presentToLogin(id: Int)
     case showOnMap(FlowerSpotEntity)
+    case didUpdateFlowerSpot(FlowerSpotEntity)
   }
 
   public var body: some ReducerOf<Self> {

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailLargeContentView.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailLargeContentView.swift
@@ -134,6 +134,7 @@ public struct FlowerSpotDetailLargeContentView: View {
         sectionDivider
         flowerInfoSection
       }
+      .background(ScrollViewConfigurator(bounces: false))
     }
     .background(ColorSet.Background.Primary)
   }

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailLargeContentView.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailLargeContentView.swift
@@ -34,45 +34,46 @@ public struct FlowerSpotDetailLargeContentView: View {
   }
 
   public var body: some View {
-    NavigationStack(path: $store.path) {
-      ZStack {
-        VStack(spacing: .Number0) {
-          navigationBar
-          mainScrollContent
-          floatingButton
-        }
-
-        ToastView(message: $store.toastMessage)
-          .padding(.bottom, .Number80)
-
-        if store.isShowLoginAlert {
-          PIDAlert(
-            type: .login,
-            closeAction: { store.send(.alertCancelTapped) },
-            acceptAction: { store.send(.alertAcceptTapped) }
-          )
-        }
+    ZStack {
+      VStack(spacing: .Number0) {
+        navigationBar
+        mainScrollContent
+        floatingButton
       }
-      .navigationDestination(for: FlowerSpotDetailFeature.Path.self) { path in
-        switch path {
-        case .photoGallery:
-          PhotoGalleryView(
-            images: store.flowerSpotData.images,
-            prefetchedImages: store.prefetchedImages,
-            title: store.flowerSpotData.streetName,
-            onImageTapped: { index in
-              store.send(.presentPhotoViewer(index: index))
-            },
-            onBackTapped: {
-              store.send(.popFromPhotoGallery)
-            },
-            onImageLoaded: { url, data in
-              store.send(.cacheImage(url: url, data: data))
-            }
-          )
-        }
+
+      ToastView(message: $store.toastMessage)
+        .padding(.bottom, .Number80)
+
+      if store.isShowLoginAlert {
+        PIDAlert(
+          type: .login,
+          closeAction: { store.send(.alertCancelTapped) },
+          acceptAction: { store.send(.alertAcceptTapped) }
+        )
+      }
+
+      if store.isPresentPhotoGallery {
+        PhotoGalleryView(
+          images: store.flowerSpotData.images,
+          prefetchedImages: store.prefetchedImages,
+          title: store.flowerSpotData.streetName,
+          onImageTapped: { index in
+            store.send(.presentPhotoViewer(index: index))
+          },
+          onBackTapped: {
+            store.send(.popFromPhotoGallery)
+          },
+          onImageLoaded: { url, data in
+            store.send(.cacheImage(url: url, data: data))
+          }
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.top, UIApplication.shared.safeAreaTopInset)
+        .background(ColorSet.Background.Primary)
+        .transition(.move(edge: .trailing))
       }
     }
+    .animation(.easeInOut(duration: 0.25), value: store.isPresentPhotoGallery)
     .fullScreenCover(isPresented: $store.isPresentPhotoViewer, onDismiss: {
       store.send(.cleanupPhotoViewer)
     }) {
@@ -118,7 +119,7 @@ public struct FlowerSpotDetailLargeContentView: View {
           }
       }
     )
-    .padding(.top, .Number20)
+    .padding(.top, UIApplication.shared.safeAreaTopInset)
   }
 
   // MARK: - Main Scroll Content

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailLargeContentView.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailLargeContentView.swift
@@ -42,7 +42,7 @@ public struct FlowerSpotDetailLargeContentView: View {
       }
 
       ToastView(message: $store.toastMessage)
-        .padding(.bottom, .Number80)
+        .padding(.bottom, .Number120)
 
       if store.isShowLoginAlert {
         PIDAlert(

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailSmallContentView.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotDetailSmallContentView.swift
@@ -25,8 +25,8 @@ public struct FlowerSpotDetailSmallContentView: View {
   }
 
   public var body: some View {
-    HStack(alignment: .top, spacing: .Number12) {
-      VStack(alignment: .leading, spacing: .Number8) {
+    HStack(alignment: .center, spacing: .Number12) {
+      VStack(alignment: .leading, spacing: .Number10) {
         titleSection
         tagSection
       }
@@ -41,8 +41,7 @@ public struct FlowerSpotDetailSmallContentView: View {
       }
     }
     .padding(.horizontal, .Number16)
-    .padding(.top, .Number8)
-    .padding(.bottom, .Number16)
+    .padding(.vertical, .Number20)
   }
 
   // MARK: - Title Section
@@ -58,7 +57,7 @@ public struct FlowerSpotDetailSmallContentView: View {
         if let blooming = BloomStatus(rawValue: flowerSpotData.bloomingStatus) {
           HStack(spacing: 4) {
             GradiantIcon(image: .flower)
-              .size(.large)
+              .size(.small)
               .foregroundStyle(blooming.gradiant)
             Text(blooming.text)
               .fontStyle(FontSet.Label.label2)

--- a/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotImageGalleryView.swift
+++ b/Projects/Feature/FlowerSpotDetail/FlowerSpotDetailFeatureInterface/Sources/FlowerSpotImageGalleryView.swift
@@ -69,8 +69,7 @@ public struct FlowerSpotImageGalleryView: View {
       .frame(height: imageHeight)
       .frame(maxWidth: .infinity)
       .clipped()
-      .cornerRadius(10)
-      
+
       if let dateText = image.createdAt?.photoDateText() {
         // 하단 그라디언트 오버레이 + 텍스트
         VStack {
@@ -98,6 +97,7 @@ public struct FlowerSpotImageGalleryView: View {
         }
       }
     }
+    .cornerRadius(10)
   }
 
   // MARK: - Two Images (2장)
@@ -118,8 +118,7 @@ public struct FlowerSpotImageGalleryView: View {
           )
           .frame(width: imageWidth, height: imageHeight)
           .clipped()
-          .cornerRadius(10)
-          
+
             if let dateText = image.createdAt?.photoDateText() {
               // 하단 그라디언트 오버레이 + 텍스트
               VStack {
@@ -147,6 +146,7 @@ public struct FlowerSpotImageGalleryView: View {
               }
             }
           }
+          .cornerRadius(10)
         }
       }
     }
@@ -170,8 +170,7 @@ public struct FlowerSpotImageGalleryView: View {
             )
             .frame(width: imageHeight, height: imageHeight)
             .clipped()
-            .cornerRadius(10)
-            
+
             if let dateText = image.createdAt?.photoDateText() {
               // 하단 그라디언트 오버레이 + 텍스트
               VStack {
@@ -199,6 +198,7 @@ public struct FlowerSpotImageGalleryView: View {
               }
             }
           }
+          .cornerRadius(10)
         }
 
         // 더보기 버튼

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
@@ -194,10 +194,7 @@ extension MapFeature {
         // MARK: - Delegate
 
       case .pushToSetting:
-        return .concatenate(
-          .send(.markerTapped(id: nil)),
-          .send(.delegate(.pushToSetting))
-        )
+        return .send(.delegate(.pushToSetting))
 
       // MARK: - FlowerSpotDetailFeature Delegate 처리
       case let .flowerSpotDetail(.delegate(action)):

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
@@ -198,10 +198,6 @@ extension MapFeature {
 
       // MARK: - FlowerSpotDetailFeature 처리
 
-      case let .flowerSpotDetail(.detailResponse(item, _)):
-        state.flowerSpots[item.id] = item
-        return .none
-
       case let .flowerSpotDetail(.delegate(action)):
         switch action {
         case .dismiss:
@@ -217,8 +213,12 @@ extension MapFeature {
           return .send(.delegate(.presentToLogin(id: id)))
 
         case let .showOnMap(flowerSpot):
-          state.mapSearch.searchResult = flowerSpot 
+          state.mapSearch.searchResult = flowerSpot
           return .send(.location(.moveLocation(flowerSpot.pinPoint)))
+
+        case let .didUpdateFlowerSpot(item):
+          state.flowerSpots[item.id] = item
+          return .none
         }
         
       case let .searchRegionList(.delegate(action)):

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
@@ -196,7 +196,12 @@ extension MapFeature {
       case .pushToSetting:
         return .send(.delegate(.pushToSetting))
 
-      // MARK: - FlowerSpotDetailFeature Delegate 처리
+      // MARK: - FlowerSpotDetailFeature 처리
+
+      case let .flowerSpotDetail(.detailResponse(item, _)):
+        state.flowerSpots[item.id] = item
+        return .none
+
       case let .flowerSpotDetail(.delegate(action)):
         switch action {
         case .dismiss:

--- a/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
+++ b/Projects/Feature/Map/MapFeature/Sources/MapFeature/MapFeature.swift
@@ -194,7 +194,10 @@ extension MapFeature {
         // MARK: - Delegate
 
       case .pushToSetting:
-        return .send(.delegate(.pushToSetting))
+        return .concatenate(
+          .send(.markerTapped(id: nil)),
+          .send(.delegate(.pushToSetting))
+        )
 
       // MARK: - FlowerSpotDetailFeature Delegate 처리
       case let .flowerSpotDetail(.delegate(action)):

--- a/Projects/Feature/Map/MapFeatureInterface/Sources/MapView/View/MapViewRepresentable.swift
+++ b/Projects/Feature/Map/MapFeatureInterface/Sources/MapView/View/MapViewRepresentable.swift
@@ -83,14 +83,17 @@ struct MapViewRepresentable: UIViewRepresentable {
     }
     
     // 마커 데이터가 변경되었을 때 마커 업데이트
-    if !flowerPositions.isEmpty && context.coordinator.currentFlowerPositions != flowerPositions {
+    if context.coordinator.currentFlowerPositions != flowerPositions {
       // 기존 마커 삭제
       if !context.coordinator.markers.isEmpty {
         context.coordinator.deleteAllMarkers()
       }
-      // 새로운 마커 표시
-      presentMarkers(uiView, flowers: flowerPositions, context: context)
-      context.coordinator.currentFlowerPositions = flowerPositions
+      
+      if !flowerPositions.isEmpty {
+        // 새로운 마커 표시
+        presentMarkers(uiView, flowers: flowerPositions, context: context)
+        context.coordinator.currentFlowerPositions = flowerPositions
+      }
     }
     
     // 마커 탭 이벤트 시

--- a/Projects/Feature/Map/MapFeatureInterface/Sources/MapView/View/MapViewRepresentable.swift
+++ b/Projects/Feature/Map/MapFeatureInterface/Sources/MapView/View/MapViewRepresentable.swift
@@ -84,14 +84,17 @@ struct MapViewRepresentable: UIViewRepresentable {
     
     // 마커 데이터가 변경되었을 때 마커 업데이트
     if context.coordinator.currentFlowerPositions != flowerPositions {
+      // 마커 ID 세트가 변경된 경우에만 카메라 이동 (데이터만 갱신된 경우 스킵)
+      let shouldMoveCamera = Set(context.coordinator.currentFlowerPositions.keys) != Set(flowerPositions.keys)
+
       // 기존 마커 삭제
       if !context.coordinator.markers.isEmpty {
         context.coordinator.deleteAllMarkers()
       }
-      
+
       if !flowerPositions.isEmpty {
         // 새로운 마커 표시
-        presentMarkers(uiView, flowers: flowerPositions, context: context)
+        presentMarkers(uiView, flowers: flowerPositions, context: context, shouldMoveCamera: shouldMoveCamera)
         context.coordinator.currentFlowerPositions = flowerPositions
       }
     }
@@ -365,10 +368,17 @@ extension MapViewRepresentable {
   }
   
   /// 지도 위에 비활성화 마커를 표시하기 위한 메서드
-  private func presentMarkers(_ view: NMFNaverMapView, flowers: [Int: FlowerSpotEntity], context: Context) {
-    // 마커 중간지점으로 카메라 이동
-    let mid = averageCenter(of: flowers.values.map { $0.pinPoint })
-    moveCamera(view, to: mid, zoomLevel: view.mapView.cameraPosition.zoom)
+  private func presentMarkers(
+    _ view: NMFNaverMapView,
+    flowers: [Int: FlowerSpotEntity],
+    context: Context,
+    shouldMoveCamera: Bool = true
+  ) {
+    // 마커 중간지점으로 카메라 이동 (마커 ID 비교 확인 -> 현재 보이는 마커들)
+    if shouldMoveCamera {
+      let mid = averageCenter(of: flowers.values.map { $0.pinPoint })
+      moveCamera(view, to: mid, zoomLevel: view.mapView.cameraPosition.zoom)
+    }
     
     for pin in flowers {
       let position = pin.value.pinPoint

--- a/Projects/Feature/Search/SearchFeature/Sources/SearchFeature.swift
+++ b/Projects/Feature/Search/SearchFeature/Sources/SearchFeature.swift
@@ -139,6 +139,12 @@ extension SearchFeature {
           )
         }
         
+      case .searchBarReturnTapped:
+        if let firstMatchingItem = state.searchList.first(where: { $0.name == state.searchWord }) {
+          return .send(.selectResult(firstMatchingItem))
+        }
+        return .none
+        
       // MARK: - Delegate
       
       case .dismiss:

--- a/Projects/Feature/Search/SearchFeature/Sources/SearchFeature.swift
+++ b/Projects/Feature/Search/SearchFeature/Sources/SearchFeature.swift
@@ -43,7 +43,7 @@ extension SearchFeature {
         // search_start 이벤트는 fetchRecentResult 완료 후 트래킹
         return .concatenate(
           .send(.configureSearchList),
-          .send(.searchBarFocused(true)),
+          .send(.searchBarFocused(state.searchWord.isEmpty)),
           .send(.fetchRecentResult)
         )
 
@@ -65,6 +65,14 @@ extension SearchFeature {
             scheduler: mainQueue,
             latest: true
           )
+        
+      case .backButtonTapped:
+        if state.searchWord.isEmpty {
+          return .send(.dismiss)
+        } else {
+          state.searchWord = ""
+          return .send(.showRecentList)
+        }
         
       case let .updateSearchResults(results):
         guard !state.showRecentList else {

--- a/Projects/Feature/Search/SearchFeatureInterface/Sources/Components/SearchResultList.swift
+++ b/Projects/Feature/Search/SearchFeatureInterface/Sources/Components/SearchResultList.swift
@@ -38,16 +38,20 @@ public struct SearchResultList: View {
               .foregroundStyle(ColorSet.Text.Tertiary)
           }
         }
+        .frame(maxHeight: .infinity, alignment: .center)
         Spacer()
         if let subInfo = item.subInfo {
           Text(subInfo)
             .fontStyle(FontSet.Caption.caption1)
             .foregroundStyle(ColorSet.Text.Tertiary)
+            .frame(maxHeight: .infinity, alignment: .center)
         }
       }
+      .frame(maxHeight: .infinity)
       .padding(.vertical, .Number12)
       BorderView(size: .long)
     }
+    .frame(height: .Number66)
     .contentShape(Rectangle())
     .padding(.horizontal, .Number16)
     .onTapGesture {

--- a/Projects/Feature/Search/SearchFeatureInterface/Sources/SearchFeature.swift
+++ b/Projects/Feature/Search/SearchFeatureInterface/Sources/SearchFeature.swift
@@ -41,6 +41,7 @@ public struct SearchFeature {
     case searchBarFocused(Bool)
     case configureSearchList
     case searchItem(String)
+    case backButtonTapped
     
     case updateSearchResults([PlaceSearchEntity])
     case showRecentList

--- a/Projects/Feature/Search/SearchFeatureInterface/Sources/SearchFeature.swift
+++ b/Projects/Feature/Search/SearchFeatureInterface/Sources/SearchFeature.swift
@@ -50,6 +50,7 @@ public struct SearchFeature {
     case updateRecentSearch(PlaceSearchEntity)
     case storeRecentResult([PlaceSearchEntity])
     case initialSearchBar(String?)
+    case searchBarReturnTapped
    
     
     // MARK: - Delegate

--- a/Projects/Feature/Search/SearchFeatureInterface/Sources/SearchView.swift
+++ b/Projects/Feature/Search/SearchFeatureInterface/Sources/SearchView.swift
@@ -81,7 +81,9 @@ extension SearchView {
           }
       }
     )
-    
+    .onSubmit {
+      store.send(.searchBarReturnTapped)
+    }
     .padding(.horizontal, .Number16)
     .padding(.vertical, .Number8)
   }

--- a/Projects/Feature/Search/SearchFeatureInterface/Sources/SearchView.swift
+++ b/Projects/Feature/Search/SearchFeatureInterface/Sources/SearchView.swift
@@ -77,7 +77,7 @@ extension SearchView {
         TouchArea(image: .back)
           .size(.extraLarge)
           .action {
-            store.send(.dismiss)
+            store.send(.backButtonTapped)
           }
       }
     )

--- a/Projects/Feature/Search/SearchFeatureInterface/Sources/SearchView.swift
+++ b/Projects/Feature/Search/SearchFeatureInterface/Sources/SearchView.swift
@@ -91,12 +91,16 @@ extension SearchView {
       Spacer()
       VStack(alignment: .center, spacing: .Number8) {
         Image(asset: ImageSet.emptyResult.swiftUIImage)
-        Text("최근 검색 결과가 없습니다.")
-          .fontStyle(FontSet.Body.body3)
-          .foregroundStyle(ColorSet.Text.Secondary)
+        Text(
+          store.searchWord.isEmpty ?
+          "최근 검색 결과가 없습니다."
+          : "검색 결과가 없습니다."
+        )
+        .fontStyle(FontSet.Body.body3)
+        .foregroundStyle(ColorSet.Text.Secondary)
       }
       Spacer()
     }
-
+    
   }
 }

--- a/Projects/Feature/SearchRegionList/SearchRegionListFeatureInterface/Sources/View/SearchRegionListView.swift
+++ b/Projects/Feature/SearchRegionList/SearchRegionListFeatureInterface/Sources/View/SearchRegionListView.swift
@@ -44,11 +44,10 @@ public struct SearchRegionListView: View {
     VStack(alignment: .leading, spacing: 0) {
       headerView
       
-      if store.isDataEmpty {
-        emptyView
-          .padding(.bottom, .Number33)
-      } else {
-        ScrollView {
+      ScrollView {
+        if store.isDataEmpty {
+          emptyView
+        } else {
           LazyVStack(spacing: .Number0) {
             ForEach(store.flowerSpots, id: \.id) { flowerSpot in
               RegionListItemView(
@@ -69,18 +68,17 @@ public struct SearchRegionListView: View {
   
   @ViewBuilder
   private var emptyView: some View {
-    HStack {
+    VStack(alignment: .center, spacing: .Number8) {
       Spacer()
-      VStack(alignment: .center, spacing: .Number8) {
-        Spacer()
-        Image(asset: ImageSet.emptyResult.swiftUIImage)
-        Text("검색 결과가 없습니다.")
-          .fontStyle(FontSet.Body.body3)
-          .foregroundStyle(ColorSet.Text.Secondary)
-        Spacer()
-      }
+      Image(asset: ImageSet.emptyResult.swiftUIImage)
+      Text("검색 결과가 없습니다.")
+        .fontStyle(FontSet.Body.body3)
+        .foregroundStyle(ColorSet.Text.Secondary)
       Spacer()
     }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .frame(minHeight: 300)
+    
   }
   
   @ViewBuilder

--- a/Projects/Feature/SearchRegionList/SearchRegionListFeatureInterface/Sources/View/SearchRegionListView.swift
+++ b/Projects/Feature/SearchRegionList/SearchRegionListFeatureInterface/Sources/View/SearchRegionListView.swift
@@ -49,7 +49,7 @@ public struct SearchRegionListView: View {
           .padding(.bottom, .Number33)
       } else {
         ScrollView {
-          LazyVStack(spacing: .Number12) {
+          LazyVStack(spacing: .Number0) {
             ForEach(store.flowerSpots, id: \.id) { flowerSpot in
               RegionListItemView(
                 flowerSpot: flowerSpot,

--- a/Projects/Feature/SearchRegionList/SearchRegionListFeatureInterface/Sources/View/SubViews/RegionListItemView.swift
+++ b/Projects/Feature/SearchRegionList/SearchRegionListFeatureInterface/Sources/View/SubViews/RegionListItemView.swift
@@ -24,7 +24,7 @@ public struct RegionListItemView: View {
     self.onTap = onTap
   }
   public var body: some View {
-    VStack(spacing: .Number12) {
+    VStack(alignment: .leading, spacing: .Number0) {
       HStack(alignment: .center, spacing: .Number12) {
         contentView
         
@@ -32,15 +32,12 @@ public struct RegionListItemView: View {
           RemoteImageView(urlString: previewUrl)
             .frame(width: 72, height: 72)
             .clipped()
-            .cornerRadius(16)
+            .cornerRadius(.Number16)
         }
       }
-      
-      Rectangle()
-        .frame(height: 1)
-        .foregroundStyle(ColorSet.Border.Secondary)
+      .padding(.vertical, .Number12)
+      BorderView(size: .long)
     }
-    .padding(.top, .Number12)
     .contentShape(Rectangle())
     .onTapGesture {
       onTap(flowerSpot)
@@ -50,7 +47,7 @@ public struct RegionListItemView: View {
   @ViewBuilder
   private var contentView: some View {
     HStack {
-      VStack(alignment: .leading, spacing: 0) {
+      VStack(alignment: .leading, spacing: .Number0) {
         Text(flowerSpot.streetName)
           .fontStyle(FontSet.Body.body2)
           .foregroundStyle(ColorSet.Text.Primary)
@@ -63,7 +60,7 @@ public struct RegionListItemView: View {
           }
           TagView(text: flowerSpot.recentlyVisitedCountString)
         }
-        .padding(.top, 8)
+        .padding(.top, .Number8)
         
       }
       Spacer()

--- a/Projects/Feature/Setting/SettingFeature/Sources/ProfileUpdateFeature.swift
+++ b/Projects/Feature/Setting/SettingFeature/Sources/ProfileUpdateFeature.swift
@@ -23,7 +23,7 @@ extension ProfileUpdateFeature {
     func reduce(into state: inout State, action: Action) -> Effect<Action> {
       switch action {
       case .binding(\.changeName):
-        return .send(.checkValidNickName(state.changeName))
+        return .send(.checkValidNickName(state.changeName.trimmingCharacters(in: .whitespaces)))
 
       case .onAppear:
         if let nickname = UserDefaultsKeys.username {
@@ -45,7 +45,7 @@ extension ProfileUpdateFeature {
         return .none
 
       case .saveTapped:
-        return .send(.changeNickName(state.changeName))
+        return .send(.changeNickName(state.changeName.trimmingCharacters(in: .whitespaces)))
           .throttle(id: ID.throttle, for: 0.3, scheduler: mainQueue, latest: false)
 
       case let .checkValidNickName(nickname):


### PR DESCRIPTION

## 🔎 작업 내용
### UI/UX 개선 사항
  - **꽃 상세 화면 토스트 위치 조정**: 토스트 메시지가 바텀시트와 겹치지
  않도록 하단 패딩 조정 (80 → 120)
  - **반경 검색 결과 처리 개선**: 검색 결과가 없을 때 지도에 그려진 마커
  전부 삭제하여 사용자 혼란 방지
  - **이미지 갤러리 디자인 개선**: cornerRadius를 ZStack에 적용하여 일관된
  UI 제공
  - **꽃 상세 바텀시트 레이아웃 개선**: 전반적인 레이아웃 구조 최적화
  - **꽃 지도 마커 데이터 동기화**: 마커와 실제 데이터 간 동기화 문제 해결
  - **지역 목록 빈 화면 개선**: 검색 결과가 없는 경우의 UI 레이아웃 향상
  - **텍스트 스타일 수정**: Heading2 폰트 크기 값 정정
  - **바텀시트 제스처 개선**: 확장 시 스크롤과 드래그 제스처 충돌 문제 해결

  ### 기술적 개선
  - 꽃 상세 화면의 토스트 메시지 위치 최적화
  - 지도 마커 상태 관리 로직 개선
  - 바텀시트 사용성 향상을 위한 제스처 처리 개선
## 📷 스크린샷

## 🛠️ 기타 공유 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bottom sheet: tap-to-expand, smoother drag/velocity behavior, and safer bottom padding.
  * Search: back button and return-key behave contextually; empty-state message adapts to input.
  * Photo gallery & presentation: updated animations, layout, and padding for smoother viewing.

* **Improvements**
  * Map markers update more efficiently to avoid unnecessary camera moves.
  * Region list and item layouts refined for better spacing and tap interactions.
  * Scrolling bounce can be configured to reduce unwanted overscroll.

* **Style**
  * Heading size increased and image corner handling adjusted for consistent visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->